### PR TITLE
CIF-632 - Support Magento multi store setups in GraphQL client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.commerce.cif</groupId>
     <artifactId>graphql-client</artifactId>
-    <version>0.1.5-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Generic GraphQL client</name>

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClient.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClient.java
@@ -16,8 +16,6 @@ package com.adobe.cq.commerce.graphql.client;
 
 import java.lang.reflect.Type;
 
-import com.google.gson.Gson;
-
 public interface GraphqlClient {
 
     /**
@@ -52,8 +50,7 @@ public interface GraphqlClient {
      * @param request The GraphQL request.
      * @param typeOfT The type of the expected GraphQL response 'data' field.
      * @param typeOfU The type of the elements of the expected GraphQL response 'errors' field.
-     * @param gson An optional Gson instance that should be used to deserialise the JSON response. This should only be used when the JSON
-     *            response cannot be deserialised by a standard Gson instance, or when some custom deserialisation is needed.
+     * 
      * @param <T> The generic type of the 'data' object in the JSON GraphQL response.
      * @param <U> The generic type of the elements of the 'errors' array in the JSON GraphQL response.
      * 
@@ -61,5 +58,41 @@ public interface GraphqlClient {
      * 
      * @exception RuntimeException if the GraphQL HTTP request does not return 200 or if the JSON response cannot be parsed or deserialized.
      */
-    public <T, U> GraphqlResponse<T, U> execute(GraphqlRequest request, Type typeOfT, Type typeOfU, Gson gson);
+    public <T, U> GraphqlResponse<T, U> execute(GraphqlRequest request, Type typeOfT, Type typeOfU);
+
+    /**
+     * Executes the given GraphQL request and deserializes the response data based on the types T and U.
+     * The type T is used to deserialize the 'data' object of the GraphQL response, and the type U is used
+     * to deserialize the 'errors' array of the GraphQL response.
+     * Each generic type can be a simple class or a generic class. To specify a simple class, just do:
+     * 
+     * <pre>
+     * GraphqlResponse&lt;MyData, MyError&gt; response = graphqlClient.execute(request, MyData.class, MyError.class);
+     * MyData data = response.getData();
+     * List&lt;MyError&gt; errors = response.getErrors();
+     * </pre>
+     * 
+     * To specify a generic type (usually for the type T), one can use
+     * the {@link com.google.gson.reflect.TypeToken} class. For example:
+     * 
+     * <pre>
+     * Type typeOfT = new TypeToken&lt;List&lt;String&gt;&gt;() {}.getType();
+     * GraphqlResponse&lt;List&lt;String&gt;, MyError&gt; response = graphqlClient.execute(request, typeOfT, MyError.class);
+     * List&lt;String&gt; data = response.getData();
+     * </pre>
+     * 
+     * @param request The GraphQL request.
+     * @param typeOfT The type of the expected GraphQL response 'data' field.
+     * @param typeOfU The type of the elements of the expected GraphQL response 'errors' field.
+     * @param options An object holding options that can be set when executing the request.
+     * 
+     * @param <T> The generic type of the 'data' object in the JSON GraphQL response.
+     * @param <U> The generic type of the elements of the 'errors' array in the JSON GraphQL response.
+     * 
+     * @return A GraphQL response.
+     * 
+     * @exception RuntimeException if the GraphQL HTTP request does not return 200 or if the JSON response cannot be parsed or deserialized.
+     */
+    public <T, U> GraphqlResponse<T, U> execute(GraphqlRequest request, Type typeOfT, Type typeOfU, RequestOptions options);
+
 }

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/RequestOptions.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/RequestOptions.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.graphql.client;
+
+import java.util.List;
+
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+
+import com.google.gson.Gson;
+
+/**
+ * This class is used to set various options when executing a GraphQL request.
+ */
+public class RequestOptions {
+
+    private Gson gson;
+    private List<Header> headers;
+
+    /**
+     * Sets the {@link Gson} instance that will be used to deserialise the JSON response. This should only be used when the JSON
+     * response cannot be deserialised by a standard Gson instance, or when some custom deserialisation is needed.
+     * 
+     * @param gson A custom {@link Gson} instance.
+     * @return This RequestOptions object.
+     */
+    public RequestOptions withGson(Gson gson) {
+        this.gson = gson;
+        return this;
+    }
+
+    /**
+     * Permits to define HTTP headers that will be sent with the GraphQL request.
+     * See {@link BasicHeader} for an implementation of the Header interface.
+     * 
+     * @param headers The HTTP headers.
+     * @return This RequestOptions object.
+     */
+    public RequestOptions withHeaders(List<Header> headers) {
+        this.headers = headers;
+        return this;
+    }
+
+    public Gson getGson() {
+        return gson;
+    }
+
+    public List<Header> getHeaders() {
+        return headers;
+    }
+
+}

--- a/src/test/resources/sample-graphql-request.json
+++ b/src/test/resources/sample-graphql-request.json
@@ -1,0 +1,1 @@
+{"query":"{dummy}","operationName":"customOperation","variables":{"variableName":"variableValue"}}


### PR DESCRIPTION
- added a dedicated object to set various options when executing a request: this will be used to set the `store_code` HTTP header

## Motivation and Context

Instead of having multiple variants of the `execute` method with all the optional arguments like `gson` and `headers`, and since we might introduce other options like the HTTP method `POST` or `GET` for caching, I added the new `RequestOptions` object so we have one single object for all options.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
