### PR TITLE
CIF-943 - Update GraphQL client library to support cache-able GET req…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You'll then have to setup and configure the client in your AEM instance.
 To instantiate instances of this GraphQL client, simply go the AEM OSGi configuration console and look for "GraphQL Client Configuration Factory". Add a configuration and set the following mandatory parameters:
 * `identifier`: must be unique among all GraphQL clients.
 * `url`: the URL of the GraphQL server endpoint used by this client.
+* `httpMethod`: the default HTTP method used to send requests, can be either GET or POST. This can be overriden on a request basis.
 
 The `identifier` is used by the adapter factory to resolve clients via the `cq:graphqlClient` property set on any JCR node. When this is set on a resource or the resource ancestors, one can write `GraphqlClient client = resource.adaptTo(GraphqlClient.class);`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.commerce.cif</groupId>
     <artifactId>graphql-client</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Generic GraphQL client</name>

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/HttpMethod.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/HttpMethod.java
@@ -16,7 +16,6 @@ package com.adobe.cq.commerce.graphql.client;
 
 /**
  * Represents the allowed and supported HTTP methods to send GraphQL requests.
- *
  */
 public enum HttpMethod {
     POST, GET

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/HttpMethod.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/HttpMethod.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.graphql.client;
+
+/**
+ * Represents the allowed and supported HTTP methods to send GraphQL requests.
+ *
+ */
+public enum HttpMethod {
+    POST, GET
+}

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/RequestOptions.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/RequestOptions.java
@@ -28,6 +28,7 @@ public class RequestOptions {
 
     private Gson gson;
     private List<Header> headers;
+    private HttpMethod httpMethod;
 
     /**
      * Sets the {@link Gson} instance that will be used to deserialise the JSON response. This should only be used when the JSON
@@ -53,6 +54,19 @@ public class RequestOptions {
         return this;
     }
 
+    /**
+     * Sets the HTTP method used to send the request, only GET or POST are supported.
+     * By default, the client sends a POST request. If GET is used, the underlying HTTP client
+     * will automatically URL-Encode the GraphQL query, operation name, and variables.
+     * 
+     * @param httpMethod The HTTP method.
+     * @return This RequestOptions object.
+     */
+    public RequestOptions withHttpMethod(HttpMethod httpMethod) {
+        this.httpMethod = httpMethod;
+        return this;
+    }
+
     public Gson getGson() {
         return gson;
     }
@@ -61,4 +75,7 @@ public class RequestOptions {
         return headers;
     }
 
+    public HttpMethod getHttpMethod() {
+        return httpMethod;
+    }
 }

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfiguration.java
@@ -18,6 +18,8 @@ import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.AttributeType;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
+import com.adobe.cq.commerce.graphql.client.HttpMethod;
+
 @ObjectClassDefinition(name = "CIF GraphQL Client Configuration Factory")
 public @interface GraphqlClientConfiguration {
 
@@ -41,6 +43,12 @@ public @interface GraphqlClientConfiguration {
         type = AttributeType.STRING,
         required = true)
     String url();
+
+    @AttributeDefinition(
+        name = "Default HTTP method",
+        description = "The default HTTP method used to send GraphQL requests.",
+        required = true)
+    HttpMethod httpMethod() default HttpMethod.POST;
 
     @AttributeDefinition(
         name = "Accept self-signed SSL certificates",

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
@@ -16,6 +16,8 @@ package com.adobe.cq.commerce.graphql.client.impl;
 
 import java.lang.annotation.Annotation;
 
+import com.adobe.cq.commerce.graphql.client.HttpMethod;
+
 public class MockGraphqlClientConfiguration implements Annotation, GraphqlClientConfiguration {
 
     public static final String URL = "https://hostname/graphql";
@@ -28,6 +30,11 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
     @Override
     public String url() {
         return URL;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return HttpMethod.POST;
     }
 
     @Override


### PR DESCRIPTION
…uests

- added support for GET requests and defined POST as default method for backwards compatibility

## Motivation and Context

This is required to support cacheable GraphQL requests with Magento 2.3.2.

## How Has This Been Tested?

Extended unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
