### PR TITLE
Timeout configuration for graphql client, and bugfix

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfiguration.java
@@ -29,7 +29,7 @@ public @interface GraphqlClientConfiguration {
     int MAX_HTTP_CONNECTIONS_DEFAULT = 20;
     boolean ACCEPT_SELF_SIGNED_CERTIFICATES = false;
 
-    int DEFAULT_CONN_TIMEOUT = 30000;
+    int DEFAULT_CONN_TIMEOUT = 5000;
     int DEFAULT_SO_TIMEOUT = 5000;
     int DEFAULT_REQPOOL_TIMEOUT = 2000;
 
@@ -68,19 +68,19 @@ public @interface GraphqlClientConfiguration {
 
     @AttributeDefinition(
         name = "Http connection timeout",
-        description = "The timeout in milliseconds for the http request",
+        description = "The timeout in milliseconds until a connection is established. A timeout value of zero is interpreted as an infinite timeout.",
         type = AttributeType.INTEGER)
-    int conn_timeout() default DEFAULT_CONN_TIMEOUT;
+    int connTimeout() default DEFAULT_CONN_TIMEOUT;
 
     @AttributeDefinition(
         name = "Http socket timeout",
-        description = "The timeout in milliseconds for the socket",
+        description = "The socket timeout in milliseconds, which is the timeout for waiting for data or, put differently, a maximum period inactivity between two consecutive data packets. A timeout value of zero is interpreted as an infinite timeout.",
         type = AttributeType.INTEGER)
-    int so_timeout() default DEFAULT_SO_TIMEOUT;
+    int soTimeout() default DEFAULT_SO_TIMEOUT;
 
     @AttributeDefinition(
         name = "Request pool timeout",
-        description = "The timeout in milliseconds for the connectionpool to return a connection.",
+        description = "The timeout in milliseconds used when requesting a connection from the connection manager. A timeout value of zero is interpreted as an infinite timeout.",
         type = AttributeType.INTEGER)
-    int reqpool_timeout() default DEFAULT_REQPOOL_TIMEOUT;
+    int reqpoolTimeout() default DEFAULT_REQPOOL_TIMEOUT;
 }

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfiguration.java
@@ -23,11 +23,15 @@ import com.adobe.cq.commerce.graphql.client.HttpMethod;
 @ObjectClassDefinition(name = "CIF GraphQL Client Configuration Factory")
 public @interface GraphqlClientConfiguration {
 
-    public String CQ_GRAPHQL_CLIENT = "cq:graphqlClient";
-    public String DEFAULT_IDENTIFIER = "default";
+    String CQ_GRAPHQL_CLIENT = "cq:graphqlClient";
+    String DEFAULT_IDENTIFIER = "default";
 
-    public static final int MAX_HTTP_CONNECTIONS_DEFAULT = 20;
-    public static final boolean ACCEPT_SELF_SIGNED_CERTIFICATES = false;
+    int MAX_HTTP_CONNECTIONS_DEFAULT = 20;
+    boolean ACCEPT_SELF_SIGNED_CERTIFICATES = false;
+
+    int DEFAULT_CONN_TIMEOUT = 30000;
+    int DEFAULT_SO_TIMEOUT = 5000;
+    int DEFAULT_REQPOOL_TIMEOUT = 2000;
 
     @AttributeDefinition(
         name = "GraphQL Service Identifier",
@@ -61,4 +65,22 @@ public @interface GraphqlClientConfiguration {
         description = "The maximum number of concurrent HTTP connections the connector can make",
         type = AttributeType.INTEGER)
     int maxHttpConnections() default MAX_HTTP_CONNECTIONS_DEFAULT;
+
+    @AttributeDefinition(
+        name = "Http connection timeout",
+        description = "The timeout in milliseconds for the http request",
+        type = AttributeType.INTEGER)
+    int conn_timeout() default DEFAULT_CONN_TIMEOUT;
+
+    @AttributeDefinition(
+        name = "Http socket timeout",
+        description = "The timeout in milliseconds for the socket",
+        type = AttributeType.INTEGER)
+    int so_timeout() default DEFAULT_SO_TIMEOUT;
+
+    @AttributeDefinition(
+        name = "Request pool timeout",
+        description = "The timeout in milliseconds for the connectionpool to return a connection.",
+        type = AttributeType.INTEGER)
+    int reqpool_timeout() default DEFAULT_REQPOOL_TIMEOUT;
 }

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfiguration.java
@@ -29,9 +29,9 @@ public @interface GraphqlClientConfiguration {
     int MAX_HTTP_CONNECTIONS_DEFAULT = 20;
     boolean ACCEPT_SELF_SIGNED_CERTIFICATES = false;
 
-    int DEFAULT_CONN_TIMEOUT = 5000;
-    int DEFAULT_SO_TIMEOUT = 5000;
-    int DEFAULT_REQPOOL_TIMEOUT = 2000;
+    int DEFAULT_CONNECTION_TIMEOUT = 5000;
+    int DEFAULT_SOCKET_TIMEOUT = 5000;
+    int DEFAULT_REQUESTPOOL_TIMEOUT = 2000;
 
     @AttributeDefinition(
         name = "GraphQL Service Identifier",
@@ -70,17 +70,17 @@ public @interface GraphqlClientConfiguration {
         name = "Http connection timeout",
         description = "The timeout in milliseconds until a connection is established. A timeout value of zero is interpreted as an infinite timeout.",
         type = AttributeType.INTEGER)
-    int connTimeout() default DEFAULT_CONN_TIMEOUT;
+    int connectionTimeout() default DEFAULT_CONNECTION_TIMEOUT;
 
     @AttributeDefinition(
         name = "Http socket timeout",
         description = "The socket timeout in milliseconds, which is the timeout for waiting for data or, put differently, a maximum period inactivity between two consecutive data packets. A timeout value of zero is interpreted as an infinite timeout.",
         type = AttributeType.INTEGER)
-    int soTimeout() default DEFAULT_SO_TIMEOUT;
+    int socketTimeout() default DEFAULT_SOCKET_TIMEOUT;
 
     @AttributeDefinition(
         name = "Request pool timeout",
         description = "The timeout in milliseconds used when requesting a connection from the connection manager. A timeout value of zero is interpreted as an infinite timeout.",
         type = AttributeType.INTEGER)
-    int reqpoolTimeout() default DEFAULT_REQPOOL_TIMEOUT;
+    int requestPoolTimeout() default DEFAULT_REQUESTPOOL_TIMEOUT;
 }

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -67,9 +67,9 @@ public class GraphqlClientImpl implements GraphqlClient {
     private boolean acceptSelfSignedCertificates;
     private int maxHttpConnections;
     private HttpMethod httpMethod;
-    private int connTimeout;
-    private int soTimeout;
-    private int reqpoolTimeout;
+    private int connectionTimeout;
+    private int socketTimeout;
+    private int requestPoolTimeout;
 
     @Activate
     public void activate(GraphqlClientConfiguration configuration) throws Exception {
@@ -78,9 +78,9 @@ public class GraphqlClientImpl implements GraphqlClient {
         acceptSelfSignedCertificates = configuration.acceptSelfSignedCertificates();
         maxHttpConnections = configuration.maxHttpConnections();
         httpMethod = configuration.httpMethod();
-        connTimeout = configuration.connTimeout();
-        soTimeout = configuration.soTimeout();
-        reqpoolTimeout = configuration.reqpoolTimeout();
+        connectionTimeout = configuration.connectionTimeout();
+        socketTimeout = configuration.socketTimeout();
+        requestPoolTimeout = configuration.requestPoolTimeout();
 
         client = buildHttpClient();
         gson = new Gson();
@@ -151,9 +151,9 @@ public class GraphqlClientImpl implements GraphqlClient {
         cm.setDefaultMaxPerRoute(maxHttpConnections); // we just have one route to the GraphQL endpoint
 
         RequestConfig requestConfig = RequestConfig.custom()
-            .setConnectTimeout(connTimeout)
-            .setSocketTimeout(soTimeout)
-            .setConnectionRequestTimeout(reqpoolTimeout)
+            .setConnectTimeout(connectionTimeout)
+            .setSocketTimeout(socketTimeout)
+            .setConnectionRequestTimeout(requestPoolTimeout)
             .build();
 
         return HttpClientBuilder.create()

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -21,7 +21,12 @@ import java.util.List;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.http.*;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpUriRequest;

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -49,9 +49,8 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class GraphqlClientImplTest {
 

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
@@ -48,18 +48,18 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
     }
 
     @Override
-    public int connTimeout() {
-        return GraphqlClientConfiguration.DEFAULT_CONN_TIMEOUT;
+    public int connectionTimeout() {
+        return GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT;
     }
 
     @Override
-    public int soTimeout() {
-        return GraphqlClientConfiguration.DEFAULT_SO_TIMEOUT;
+    public int socketTimeout() {
+        return GraphqlClientConfiguration.DEFAULT_SOCKET_TIMEOUT;
     }
 
     @Override
-    public int reqpoolTimeout() {
-        return GraphqlClientConfiguration.DEFAULT_REQPOOL_TIMEOUT;
+    public int requestPoolTimeout() {
+        return GraphqlClientConfiguration.DEFAULT_REQUESTPOOL_TIMEOUT;
     }
 
     @Override

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
@@ -48,17 +48,17 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
     }
 
     @Override
-    public int conn_timeout() {
+    public int connTimeout() {
         return GraphqlClientConfiguration.DEFAULT_CONN_TIMEOUT;
     }
 
     @Override
-    public int so_timeout() {
+    public int soTimeout() {
         return GraphqlClientConfiguration.DEFAULT_SO_TIMEOUT;
     }
 
     @Override
-    public int reqpool_timeout() {
+    public int reqpoolTimeout() {
         return GraphqlClientConfiguration.DEFAULT_REQPOOL_TIMEOUT;
     }
 

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
@@ -48,6 +48,21 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
     }
 
     @Override
+    public int conn_timeout() {
+        return GraphqlClientConfiguration.DEFAULT_CONN_TIMEOUT;
+    }
+
+    @Override
+    public int so_timeout() {
+        return GraphqlClientConfiguration.DEFAULT_SO_TIMEOUT;
+    }
+
+    @Override
+    public int reqpool_timeout() {
+        return GraphqlClientConfiguration.DEFAULT_REQPOOL_TIMEOUT;
+    }
+
+    @Override
     public Class<? extends Annotation> annotationType() {
         return GraphqlClientConfiguration.class;
     }


### PR DESCRIPTION
Added configuration for setting the timeout request configuration for the http client which was not possible, and consumed the response when the status is not 200. This caused the connections to be not cleaned up, and flood the connectionpool

<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Added requestConfig for the http client to set the socket, connection and pool timeout
2. Added a line to consume the response, when it is not status 200.

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/commerce-cif-connector/issues/48


## Motivation and Context
When the magento graphql service is malfunctioning and returning http error states, these connections will remain in the pool, until it is full, locking the client. Also added configuration to set timeouts in the service

## How Has This Been Tested?
Used a apache service to return responses with a error code. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Is it a feature to prevent a bug or a bugfix. Let's check both.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My change requires a change to the documentation.
-> Update documentation for the configuration of the graphql-client to add timeout values.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
Not sure, since the changes are configuration for the http client, which is mocked in the tests.
Can you help out?
- [ ] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
