### PR TITLE
CIF-1046 - CIF GraphQL client has issues with HTTP errors and connect…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,6 +390,12 @@
             <classifier>runtime</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+            <version>5.6.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>3.0.0-M3</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader> <!-- Required for CircleCI -->
                     <systemPropertyVariables>

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -37,7 +37,7 @@ import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -143,7 +143,7 @@ public class GraphqlClientImpl implements GraphqlClient {
         SSLConnectionSocketFactory sslsf = null;
         if (acceptSelfSignedCertificates) {
             LOGGER.warn("Self-signed SSL certificates are accepted. This should NOT be done on production systems!");
-            SSLContext sslContext = SSLContextBuilder.create().loadTrustMaterial(new TrustSelfSignedStrategy()).build();
+            SSLContext sslContext = SSLContextBuilder.create().loadTrustMaterial(new TrustAllStrategy()).build();
             sslsf = new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
         } else {
             sslsf = new SSLConnectionSocketFactory(SSLContexts.createDefault(), new DefaultHostnameVerifier());

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
@@ -188,6 +188,6 @@ public class ConcurrencyTest {
     }
 
     private static String getResource(String filename) throws IOException {
-        return IOUtils.toString(GraphqlClientImplTest.class.getClassLoader().getResourceAsStream(filename), StandardCharsets.UTF_8);
+        return IOUtils.toString(ConcurrencyTest.class.getClassLoader().getResourceAsStream(filename), StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
@@ -39,7 +39,7 @@ import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockserver.model.HttpStatusCode.INTERNAL_SERVER_ERROR_500;;
+import static org.mockserver.model.HttpStatusCode.INTERNAL_SERVER_ERROR_500;
 
 public class ConcurrencyTest {
 

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
@@ -126,7 +126,8 @@ public class ConcurrencyTest {
             .withStatusCode(INTERNAL_SERVER_ERROR_500.code())
             .withReasonPhrase(INTERNAL_SERVER_ERROR_500.reasonPhrase())
             .withHeader(HttpHeaders.CONNECTION, "keep-alive")
-            .withBody("Dummy content that MUST be consumed by the client");
+            .withBody("Dummy content that MUST be consumed by the client")
+            .withDelay(TimeUnit.MILLISECONDS, 50);
 
         mockServer.reset()
             .when(HttpRequest.request().withPath("/graphql"))
@@ -161,7 +162,7 @@ public class ConcurrencyTest {
             .withStatusCode(INTERNAL_SERVER_ERROR_500.code())
             .withReasonPhrase(INTERNAL_SERVER_ERROR_500.reasonPhrase())
             .withHeader(HttpHeaders.CONNECTION, "keep-alive")
-            .withDelay(TimeUnit.SECONDS, 60);
+            .withDelay(TimeUnit.SECONDS, 60); // Must be higher than test timeout
 
         mockServer.reset()
             .when(HttpRequest.request().withPath("/graphql"))

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
@@ -1,0 +1,192 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.graphql.client.impl;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHeaders;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
+import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockserver.model.HttpStatusCode.INTERNAL_SERVER_ERROR_500;;
+
+public class ConcurrencyTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrencyTest.class);
+    private static final int THREAD_COUNT = GraphqlClientConfiguration.MAX_HTTP_CONNECTIONS_DEFAULT * 2;
+
+    private static ClientAndServer mockServer;
+
+    private static class Data {
+        String text;
+        Integer count;
+    }
+
+    private static class Error {
+        String message;
+    }
+
+    private GraphqlClientImpl graphqlClient;
+    private GraphqlRequest dummy = new GraphqlRequest("{dummy}");
+
+    @BeforeClass
+    public static void initServer() throws IOException {
+        mockServer = ClientAndServer.startClientAndServer();
+        LOGGER.info("Started HTTP mock server on port {}", mockServer.getLocalPort());
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        mockServer.stop();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MockGraphqlClientConfiguration config = new MockGraphqlClientConfiguration();
+        config.setUrl("https://localhost:" + mockServer.getLocalPort() + "/graphql");
+        config.setAcceptSelfSignedCertificates(true);
+
+        graphqlClient = new GraphqlClientImpl();
+        graphqlClient.activate(config);
+    }
+
+    @Test(timeout = 15000)
+    public void testConcurrencyWithResponses() throws Exception {
+        String json = getResource("sample-graphql-response.json");
+        mockServer.reset()
+            .when(HttpRequest.request().withPath("/graphql"))
+            .respond(HttpResponse
+                .response()
+                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .withHeader(HttpHeaders.CONNECTION, "keep-alive")
+                .withBody(json)
+                .withDelay(TimeUnit.MILLISECONDS, 50));
+
+        ExecutorService service = Executors.newFixedThreadPool(THREAD_COUNT);
+        Collection<Future<GraphqlResponse<Data, Error>>> futures = new ArrayList<>(THREAD_COUNT);
+        for (int t = 0; t < THREAD_COUNT; t++) {
+            futures.add(service.submit(() -> graphqlClient.execute(dummy, Data.class, Error.class)));
+        }
+
+        Collection<GraphqlResponse<Data, Error>> responses = new ArrayList<>();
+        for (Future<GraphqlResponse<Data, Error>> f : futures) {
+            responses.add(f.get());
+        }
+
+        assertEquals(THREAD_COUNT, responses.size());
+        for (GraphqlResponse<Data, Error> response : responses) {
+            assertEquals("Some text", response.getData().text);
+            assertEquals(42, response.getData().count.intValue());
+
+            // Check the response errors
+            assertEquals(1, response.getErrors().size());
+            Error error = response.getErrors().get(0);
+            assertEquals("Error message", error.message);
+        }
+    }
+
+    @Test(timeout = 15000)
+    public void testConcurrencyWithErrors() throws Exception {
+
+        // If the error messages are not consumed by the client, this test will time out
+        // because all threads from the connection pool will stay stuck
+
+        HttpResponse error = new HttpResponse()
+            .withStatusCode(INTERNAL_SERVER_ERROR_500.code())
+            .withReasonPhrase(INTERNAL_SERVER_ERROR_500.reasonPhrase())
+            .withHeader(HttpHeaders.CONNECTION, "keep-alive")
+            .withBody("Dummy content that MUST be consumed by the client");
+
+        mockServer.reset()
+            .when(HttpRequest.request().withPath("/graphql"))
+            .respond(error);
+
+        ExecutorService service = Executors.newFixedThreadPool(THREAD_COUNT);
+        Collection<Future<GraphqlResponse<Data, Error>>> futures = new ArrayList<>(THREAD_COUNT);
+        for (int t = 0; t < THREAD_COUNT; t++) {
+            futures.add(service.submit(() -> {
+                try {
+                    return graphqlClient.execute(dummy, Data.class, Error.class);
+                } catch (Exception e) {
+                    return null;
+                }
+            }));
+        }
+
+        Collection<GraphqlResponse<Data, Error>> responses = new ArrayList<>();
+        for (Future<GraphqlResponse<Data, Error>> f : futures) {
+            responses.add(f.get());
+        }
+        assertEquals(THREAD_COUNT, responses.size());
+    }
+
+    @Test(timeout = 15000)
+    public void testConcurrencyWithTimeout() throws Exception {
+
+        // The timeout of the HTTP client is much smaller than the timeout we define in the mock server
+        // so we expect that all connection attemps will properly time out before the test itself times out
+
+        HttpResponse error = new HttpResponse()
+            .withStatusCode(INTERNAL_SERVER_ERROR_500.code())
+            .withReasonPhrase(INTERNAL_SERVER_ERROR_500.reasonPhrase())
+            .withHeader(HttpHeaders.CONNECTION, "keep-alive")
+            .withDelay(TimeUnit.SECONDS, 60);
+
+        mockServer.reset()
+            .when(HttpRequest.request().withPath("/graphql"))
+            .respond(error);
+
+        ExecutorService service = Executors.newFixedThreadPool(THREAD_COUNT);
+        Collection<Future<GraphqlResponse<Data, Error>>> futures = new ArrayList<>(THREAD_COUNT);
+        for (int t = 0; t < THREAD_COUNT; t++) {
+            futures.add(service.submit(() -> {
+                try {
+                    return graphqlClient.execute(dummy, Data.class, Error.class);
+                } catch (Exception e) {
+                    return null;
+                }
+            }));
+        }
+
+        Collection<GraphqlResponse<Data, Error>> responses = new ArrayList<>();
+        for (Future<GraphqlResponse<Data, Error>> f : futures) {
+            responses.add(f.get());
+        }
+        assertEquals(THREAD_COUNT, responses.size());
+    }
+
+    private static String getResource(String filename) throws IOException {
+        return IOUtils.toString(GraphqlClientImplTest.class.getClassLoader().getResourceAsStream(filename), StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
@@ -21,6 +21,8 @@ import com.adobe.cq.commerce.graphql.client.HttpMethod;
 public class MockGraphqlClientConfiguration implements Annotation, GraphqlClientConfiguration {
 
     public static final String URL = "https://hostname/graphql";
+    private String url;
+    private Boolean acceptSelfSignedCertificates;
 
     @Override
     public String identifier() {
@@ -29,7 +31,7 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
 
     @Override
     public String url() {
-        return URL;
+        return url != null ? url : URL;
     }
 
     @Override
@@ -39,7 +41,8 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
 
     @Override
     public boolean acceptSelfSignedCertificates() {
-        return GraphqlClientConfiguration.ACCEPT_SELF_SIGNED_CERTIFICATES;
+        return acceptSelfSignedCertificates != null ? acceptSelfSignedCertificates
+            : GraphqlClientConfiguration.ACCEPT_SELF_SIGNED_CERTIFICATES;
     }
 
     @Override
@@ -65,5 +68,13 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
     @Override
     public Class<? extends Annotation> annotationType() {
         return GraphqlClientConfiguration.class;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public void setAcceptSelfSignedCertificates(boolean acceptSelfSignedCertificates) {
+        this.acceptSelfSignedCertificates = acceptSelfSignedCertificates;
     }
 }

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,6 @@
+# See https://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html for the syntax of this file
+
+# Disable logger during tests
+org.slf4j.simpleLogger.log.org.mockserver.mock.HttpStateHandler=off
+org.slf4j.simpleLogger.log.com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl=off
+org.slf4j.simpleLogger.log.com.adobe.cq.commerce.graphql.client.impl.GraphqlClientAdapterFactory=off


### PR DESCRIPTION
…ion timeouts

- added some unit tests to test the concurrency and thread pool of the underlying HTTP client

The tests fail if the HTTP client does not consume the HTTP body of error responses, and if it's not configured with the connection timeouts.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
