### PR TITLE
CIF-1203 - Update GraphQL adapter factory to use context-aware configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,18 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.caconfig-mock-plugin</artifactId>
+            <version>1.3.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.api</artifactId>
+            <version>2.20.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock</artifactId>
             <version>2.2.12</version>
             <scope>test</scope>

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactory.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactory.java
@@ -17,6 +17,7 @@ package com.adobe.cq.commerce.graphql.client.impl;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
@@ -29,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
-import com.adobe.xfa.ut.StringUtils;
 import com.day.cq.commons.inherit.ComponentInheritanceValueMap;
 import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
 import com.day.cq.commons.inherit.InheritanceValueMap;
@@ -39,8 +39,8 @@ import com.day.cq.wcm.api.PageManager;
 @Component(
     service = { AdapterFactory.class },
     property = {
-        AdapterFactory.ADAPTABLE_CLASSES + "=" + GraphqlClientAdapterFactory.RESOURCE_CLASS_NAME, AdapterFactory.ADAPTER_CLASSES + "="
-            + GraphqlClientAdapterFactory.GRAPHQLCLIENT_CLASS_NAME })
+        AdapterFactory.ADAPTABLE_CLASSES + "=" + GraphqlClientAdapterFactory.RESOURCE_CLASS_NAME,
+        AdapterFactory.ADAPTER_CLASSES + "=" + GraphqlClientAdapterFactory.GRAPHQLCLIENT_CLASS_NAME })
 public class GraphqlClientAdapterFactory implements AdapterFactory {
 
     protected static final String RESOURCE_CLASS_NAME = "org.apache.sling.api.resource.Resource";
@@ -83,7 +83,11 @@ public class GraphqlClientAdapterFactory implements AdapterFactory {
         ConfigurationBuilder configBuilder = res.adaptTo(ConfigurationBuilder.class);
         ValueMap properties = configBuilder.name(CONFIG_NAME).asValueMap();
 
-        String identifier = properties.get(GraphqlClientConfiguration.CQ_GRAPHQL_CLIENT, readFallbackConfiguration(res));
+        String identifier = properties.get(GraphqlClientConfiguration.CQ_GRAPHQL_CLIENT, String.class);
+        if (identifier == null) {
+            identifier = readFallbackConfiguration(res);
+        }
+
         if (StringUtils.isEmpty(identifier)) {
             LOGGER.error("Could not find {} property for given resource at {}", GraphqlClientConfiguration.CQ_GRAPHQL_CLIENT, res
                 .getPath());

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactory.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactory.java
@@ -47,7 +47,7 @@ public class GraphqlClientAdapterFactory implements AdapterFactory {
 
     protected static final String GRAPHQLCLIENT_CLASS_NAME = "com.adobe.cq.commerce.graphql.client.GraphqlClient";
 
-    protected static final String CONFIG_NAME = "commerce/default";
+    protected static final String CONFIG_NAME = "cloudconfigs/commerce";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphqlClientAdapterFactory.class);
 

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
@@ -15,43 +15,31 @@
 package com.adobe.cq.commerce.graphql.client.impl;
 
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
+import com.google.common.collect.ImmutableMap;
 import io.wcm.testing.mock.aem.junit.AemContext;
-import io.wcm.testing.mock.aem.junit.AemContextBuilder;
 
-import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class GraphqlClientAdapterFactoryTest {
 
-    public final static String CATALOG_IDENTIFIER = "my-catalog";
-
     @Rule
-    public final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_MOCK).plugin(CACONFIG).build();
+    public final AemContext context = GraphqlAemContext.createContext(ImmutableMap.of(
+        "/content", "/context/graphql-client-adapter-factory-context.json",
+        "/conf/test-config", "/context/jcr-conf.json"));
 
-    Resource mockConfigurationResource;
-
-    @Before
-    public void setUp() {
-        GraphqlAemContext.adapterFactory = new GraphqlClientAdapterFactory();
-
-        GraphqlClient mockClient = mock(GraphqlClient.class);
-        when(mockClient.getIdentifier()).thenReturn(CATALOG_IDENTIFIER);
-        context.registerService(GraphqlClient.class, mockClient);
-
-        // Add AdapterFactory
-        context.registerInjectActivateService(GraphqlAemContext.adapterFactory);
-
-        // Load page structure
-        context.load()
-            .json("/context/graphql-client-adapter-factory-context.json", "/content");
+    @Test
+    public void testGetClientForPageWithContextConfiguration() {
+        Resource res = context.resourceResolver().getResource("/content/pageE");
+        // Adapt page to client, verify that correct client was returned
+        GraphqlClient client = res.adaptTo(GraphqlClient.class);
+        Assert.assertNotNull("Client is not null", client);
+        Assert.assertEquals("The identifier is read correctly", GraphqlAemContext.CATALOG_IDENTIFIER, client.getIdentifier());
     }
 
     @Test

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
@@ -14,26 +14,66 @@
 
 package com.adobe.cq.commerce.graphql.client.impl;
 
+import java.util.Map;
+
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.caconfig.ConfigurationResolveException;
+import org.apache.sling.caconfig.resource.ConfigurationResourceResolver;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
 
+import com.adobe.cq.commerce.common.ValueMapDecorator;
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
+import com.google.common.collect.ImmutableMap;
+import com.sun.xml.internal.ws.developer.MemberSubmissionAddressing;
 import io.wcm.testing.mock.aem.junit.AemContext;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class GraphqlClientAdapterFactoryTest {
 
+    public final static String CATALOG_IDENTIFIER = "my-catalog";
+
     @Rule
-    public final AemContext context = GraphqlAemContext.createContext("/context/graphql-client-adapter-factory-context.json");
+    public final AemContext context = new AemContext(ResourceResolverType.JCR_MOCK);
+
+    Resource mockConfigurationResource;
+
+    @Before
+    public void setUp() {
+        GraphqlAemContext.adapterFactory = new GraphqlClientAdapterFactory();
+
+        GraphqlClient mockClient = mock(GraphqlClient.class);
+        when(mockClient.getIdentifier()).thenReturn(CATALOG_IDENTIFIER);
+        context.registerService(GraphqlClient.class, mockClient);
+
+        // Add the configuration resource resolver
+        ConfigurationResourceResolver mockConfigurationResourceResolver = mock(ConfigurationResourceResolver.class);
+        mockConfigurationResource = mock(Resource.class);
+        setupMockConfiguration(ImmutableMap.<String, Object>of("cq:graphqlClient", "my-catalog"));
+        when(mockConfigurationResourceResolver.getResource(any(Resource.class), any(String.class), any(String.class))).thenReturn(mockConfigurationResource);
+
+        context.registerService(ConfigurationResourceResolver.class, mockConfigurationResourceResolver);
+
+        // Add AdapterFactory
+        context.registerInjectActivateService(GraphqlAemContext.adapterFactory);
+
+        // Load page structure
+        context.load()
+               .json("/context/graphql-client-adapter-factory-context.json", "/content");
+    }
 
     @Test
     public void testGetClientForPageWithIdentifier() {
         // Get page which has the catalog identifier in its jcr:content node
-        Resource res = context.resourceResolver().getResource("/content/pageA");
+        Resource res = context.resourceResolver()
+                              .getResource("/content/pageA");
 
         // Adapt page to client, verify that correct client was returned
         GraphqlClient client = res.adaptTo(GraphqlClient.class);
@@ -44,7 +84,8 @@ public class GraphqlClientAdapterFactoryTest {
     @Test
     public void testGetClientForPageWithInheritedIdentifier() {
         // Get page whose parent has the catalog identifier in its jcr:content node
-        Resource res = context.resourceResolver().getResource("/content/pageB/pageC");
+        Resource res = context.resourceResolver()
+                              .getResource("/content/pageB/pageC");
 
         // Adapt page to client, verify that correct client was returned
         GraphqlClient client = res.adaptTo(GraphqlClient.class);
@@ -54,8 +95,11 @@ public class GraphqlClientAdapterFactoryTest {
 
     @Test
     public void testReturnNullForPageWithoutIdentifier() {
+        setupMockConfiguration(ImmutableMap.<String, Object>of("randomProperty", "randomValue"));
+
         // Get page whose parent has the catalog identifier in its jcr:content node
-        Resource res = context.resourceResolver().getResource("/content/pageD");
+        Resource res = context.resourceResolver()
+                              .getResource("/content/pageD");
 
         // Adapt page to client, verify that no client can be returned
         GraphqlClient client = res.adaptTo(GraphqlClient.class);
@@ -71,7 +115,8 @@ public class GraphqlClientAdapterFactoryTest {
         Assert.assertEquals(0, GraphqlAemContext.adapterFactory.clients.size());
 
         // Get page which has the catalog identifier in its jcr:content node
-        Resource res = context.resourceResolver().getResource("/content/pageA");
+        Resource res = context.resourceResolver()
+                              .getResource("/content/pageA");
 
         // Adapt page to client, verify that no client can be returned
         GraphqlClient client = res.adaptTo(GraphqlClient.class);
@@ -86,17 +131,29 @@ public class GraphqlClientAdapterFactoryTest {
         GraphqlClientAdapterFactory factory = new GraphqlClientAdapterFactory();
         factory.bindGraphqlClient(graphqlClient, null);
 
+        Map<String, Object> properties = ImmutableMap.<String, Object>of("cq:graphqlClient", "default");
+        final Resource mockConfigurationResource = mock(Resource.class);
+        when(mockConfigurationResource.getValueMap()).thenReturn(new ValueMapDecorator(properties));
+        ConfigurationResourceResolver mockConfigurationResourceResolver = mock(ConfigurationResourceResolver.class);
+        when(mockConfigurationResourceResolver.getResource(any(Resource.class), any(String.class), any(String.class))).thenReturn(mockConfigurationResource);
+        Whitebox.setInternalState(factory, "configurationResourceResolver", mockConfigurationResourceResolver);
+
         // Ensure that adapter returns null if not adapted from a resource
         Object target = factory.getAdapter(factory, Object.class);
         Assert.assertNull(target);
 
         // Ensure that adapter returns null if not adapting to a GraphQL client
-        Resource res = context.resourceResolver().getResource("/content/test");
+        Resource res = context.resourceResolver()
+                              .getResource("/content/test");
         target = factory.getAdapter(res, Object.class);
         Assert.assertNull(target);
 
         // Ensure it works in the right case
         target = factory.getAdapter(res, GraphqlClient.class);
         Assert.assertNotNull(target);
+    }
+
+    private void setupMockConfiguration(Map<String, Object> properties) {
+        when(mockConfigurationResource.getValueMap()).thenReturn(new ValueMapDecorator(properties));
     }
 }

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
@@ -14,25 +14,18 @@
 
 package com.adobe.cq.commerce.graphql.client.impl;
 
-import java.util.Map;
-
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.caconfig.ConfigurationResolveException;
-import org.apache.sling.caconfig.resource.ConfigurationResourceResolver;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.internal.util.reflection.Whitebox;
 
-import com.adobe.cq.commerce.common.ValueMapDecorator;
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
-import com.google.common.collect.ImmutableMap;
-import com.sun.xml.internal.ws.developer.MemberSubmissionAddressing;
 import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit.AemContextBuilder;
 
-import static org.mockito.Matchers.any;
+import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,7 +34,7 @@ public class GraphqlClientAdapterFactoryTest {
     public final static String CATALOG_IDENTIFIER = "my-catalog";
 
     @Rule
-    public final AemContext context = new AemContext(ResourceResolverType.JCR_MOCK);
+    public final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_MOCK).plugin(CACONFIG).build();
 
     Resource mockConfigurationResource;
 
@@ -53,27 +46,18 @@ public class GraphqlClientAdapterFactoryTest {
         when(mockClient.getIdentifier()).thenReturn(CATALOG_IDENTIFIER);
         context.registerService(GraphqlClient.class, mockClient);
 
-        // Add the configuration resource resolver
-        ConfigurationResourceResolver mockConfigurationResourceResolver = mock(ConfigurationResourceResolver.class);
-        mockConfigurationResource = mock(Resource.class);
-        setupMockConfiguration(ImmutableMap.<String, Object>of("cq:graphqlClient", "my-catalog"));
-        when(mockConfigurationResourceResolver.getResource(any(Resource.class), any(String.class), any(String.class))).thenReturn(mockConfigurationResource);
-
-        context.registerService(ConfigurationResourceResolver.class, mockConfigurationResourceResolver);
-
         // Add AdapterFactory
         context.registerInjectActivateService(GraphqlAemContext.adapterFactory);
 
         // Load page structure
         context.load()
-               .json("/context/graphql-client-adapter-factory-context.json", "/content");
+            .json("/context/graphql-client-adapter-factory-context.json", "/content");
     }
 
     @Test
     public void testGetClientForPageWithIdentifier() {
         // Get page which has the catalog identifier in its jcr:content node
-        Resource res = context.resourceResolver()
-                              .getResource("/content/pageA");
+        Resource res = context.resourceResolver().getResource("/content/pageA");
 
         // Adapt page to client, verify that correct client was returned
         GraphqlClient client = res.adaptTo(GraphqlClient.class);
@@ -84,8 +68,7 @@ public class GraphqlClientAdapterFactoryTest {
     @Test
     public void testGetClientForPageWithInheritedIdentifier() {
         // Get page whose parent has the catalog identifier in its jcr:content node
-        Resource res = context.resourceResolver()
-                              .getResource("/content/pageB/pageC");
+        Resource res = context.resourceResolver().getResource("/content/pageB/pageC");
 
         // Adapt page to client, verify that correct client was returned
         GraphqlClient client = res.adaptTo(GraphqlClient.class);
@@ -95,11 +78,8 @@ public class GraphqlClientAdapterFactoryTest {
 
     @Test
     public void testReturnNullForPageWithoutIdentifier() {
-        setupMockConfiguration(ImmutableMap.<String, Object>of("randomProperty", "randomValue"));
-
         // Get page whose parent has the catalog identifier in its jcr:content node
-        Resource res = context.resourceResolver()
-                              .getResource("/content/pageD");
+        Resource res = context.resourceResolver().getResource("/content/pageD");
 
         // Adapt page to client, verify that no client can be returned
         GraphqlClient client = res.adaptTo(GraphqlClient.class);
@@ -115,8 +95,7 @@ public class GraphqlClientAdapterFactoryTest {
         Assert.assertEquals(0, GraphqlAemContext.adapterFactory.clients.size());
 
         // Get page which has the catalog identifier in its jcr:content node
-        Resource res = context.resourceResolver()
-                              .getResource("/content/pageA");
+        Resource res = context.resourceResolver().getResource("/content/pageA");
 
         // Adapt page to client, verify that no client can be returned
         GraphqlClient client = res.adaptTo(GraphqlClient.class);
@@ -131,29 +110,17 @@ public class GraphqlClientAdapterFactoryTest {
         GraphqlClientAdapterFactory factory = new GraphqlClientAdapterFactory();
         factory.bindGraphqlClient(graphqlClient, null);
 
-        Map<String, Object> properties = ImmutableMap.<String, Object>of("cq:graphqlClient", "default");
-        final Resource mockConfigurationResource = mock(Resource.class);
-        when(mockConfigurationResource.getValueMap()).thenReturn(new ValueMapDecorator(properties));
-        ConfigurationResourceResolver mockConfigurationResourceResolver = mock(ConfigurationResourceResolver.class);
-        when(mockConfigurationResourceResolver.getResource(any(Resource.class), any(String.class), any(String.class))).thenReturn(mockConfigurationResource);
-        Whitebox.setInternalState(factory, "configurationResourceResolver", mockConfigurationResourceResolver);
-
         // Ensure that adapter returns null if not adapted from a resource
         Object target = factory.getAdapter(factory, Object.class);
         Assert.assertNull(target);
 
         // Ensure that adapter returns null if not adapting to a GraphQL client
-        Resource res = context.resourceResolver()
-                              .getResource("/content/test");
+        Resource res = context.resourceResolver().getResource("/content/test");
         target = factory.getAdapter(res, Object.class);
         Assert.assertNull(target);
 
         // Ensure it works in the right case
         target = factory.getAdapter(res, GraphqlClient.class);
         Assert.assertNotNull(target);
-    }
-
-    private void setupMockConfiguration(Map<String, Object> properties) {
-        when(mockConfigurationResource.getValueMap()).thenReturn(new ValueMapDecorator(properties));
     }
 }

--- a/src/test/resources/context/graphql-client-adapter-factory-context.json
+++ b/src/test/resources/context/graphql-client-adapter-factory-context.json
@@ -25,6 +25,13 @@
       "jcr:primaryType":"cq:PageContent"
     }
   },
+    "pageE": {
+        "jcr:primaryType": "cq:Page",
+        "jcr:content": {
+            "jcr:primaryType": "cq:PageContent",
+            "cq:conf": "/conf/test-config"
+        }
+  },
   "test": {
     "jcr:primaryType": "nt:unstructured",
     "cq:graphqlClient": "default"

--- a/src/test/resources/context/jcr-conf.json
+++ b/src/test/resources/context/jcr-conf.json
@@ -1,0 +1,18 @@
+{
+    "settings": {
+        "jcr:primaryType": "sling:Folder",
+        "commerce": {
+            "jcr:primaryType": "cq:Page",
+            "jcr:mixinTypes": [
+                "rep:AccessControllable"
+            ],
+            "jcr:createdBy": "admin",
+            "jcr:created": "Thu Jan 16 2020 12:20:34 GMT+0200",
+            "default": {
+                "jcr:primaryType": "nt:unstructured",
+                "cq:graphqlClient": "my-catalog",
+                "magentoStore": "my-store"
+            }
+        }
+    }
+}

--- a/src/test/resources/context/jcr-conf.json
+++ b/src/test/resources/context/jcr-conf.json
@@ -1,15 +1,10 @@
 {
     "settings": {
         "jcr:primaryType": "sling:Folder",
-        "commerce": {
-            "jcr:primaryType": "cq:Page",
-            "jcr:mixinTypes": [
-                "rep:AccessControllable"
-            ],
-            "jcr:createdBy": "admin",
-            "jcr:created": "Thu Jan 16 2020 12:20:34 GMT+0200",
-            "default": {
-                "jcr:primaryType": "nt:unstructured",
+        "cloudconfigs": {
+            "jcr:primaryType": "sling:Folder",
+            "commerce": {
+                "jcr:primaryType": "cq:Page ",
                 "cq:graphqlClient": "my-catalog",
                 "magentoStore": "my-store"
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The GraphQL Client adapter factory has to be updated to read the configuration data from the context (falling back to the properties of the resource). 

The implementation is straightforward - the Sling CAConfig API comes with all the required components to consume the configurations.

<!--- Describe your changes in detail -->

## Related Issue

CIF-1203

## Motivation and Context

Unify the configuration settings for the CIF connector

## How Has This Been Tested?

Unit tests and functional testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
