### PR TITLE
CIF-1429 - The GraphQL client should use a service user to read configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /target/
 pom.xml.releaseBackup
 release.properties
+/graphql-client.iml

--- a/README.md
+++ b/README.md
@@ -13,24 +13,32 @@ To build and install the latest version in a running AEM instance, simply do
 ```
 mvn clean install sling:install
 ```
+
 This installs everything by default to `localhost:4502` without any context path. You can also configure the install location with the following maven properties:
-* `aem.host`: the name of the AEM instance
-* `aem.port`: the port number of the AEM instance
-* `aem.contextPath`: the context path (if any) of your AEM instance, starting with `/`
+
+-   `aem.host`: the name of the AEM instance
+-   `aem.port`: the port number of the AEM instance
+-   `aem.contextPath`: the context path (if any) of your AEM instance, starting with `/`
 
 ## Using the GraphQL client
 
 ### Prerequisites
 
-The GraphQL client needs a service user to read the configurations, so consumers must provide one or more user mappings. The minimum privilege matrix for the service user(s) is the following:
+The GraphQL client needs a service user to read the configurations, so consumers must provide one or more user mappings. The subservice name is `graphql-client-configuration` and the minimum privilege matrix for the service user(s) is the following:
 
-| **Path**     | **Privilege** |
-| -------------- | --------------- |
+| **Path**       | **Privilege** |
+| -------------- | ------------- |
 | /conf          | jcr:read      |
 | /content       | jcr:read      |
-| /libs/settings | jcr:read       |
+| /libs/settings | jcr:read      |
 
-You can either use one service user or an aggregate of several users, each with its own privilege set.
+You can either use one service user or an aggregate of several users, each with its own privilege set. The following mapping would work in a standard AEM installation:
+
+```
+[com.adobe.commerce.cif.connector-graphql:omnisearch-service=omnisearch-service]
+```
+
+For details about how to define service user mappings in AEM you can consult [the official documentation](https://docs.adobe.com/content/help/en/experience-manager-65/administering/security/security-service-users.html)
 
 ### Using the library
 
@@ -47,14 +55,13 @@ To use this library in your project, just add the following maven dependency to 
 
 You'll then have to setup and configure the client in your AEM instance.
 
-
-
 ## OSGi configuration
 
 To instantiate instances of this GraphQL client, simply go the AEM OSGi configuration console and look for "GraphQL Client Configuration Factory". Add a configuration and set the following mandatory parameters:
-* `identifier`: must be unique among all GraphQL clients.
-* `url`: the URL of the GraphQL server endpoint used by this client.
-* `httpMethod`: the default HTTP method used to send requests, can be either GET or POST. This can be overriden on a request basis.
+
+-   `identifier`: must be unique among all GraphQL clients.
+-   `url`: the URL of the GraphQL server endpoint used by this client.
+-   `httpMethod`: the default HTTP method used to send requests, can be either GET or POST. This can be overriden on a request basis.
 
 The `identifier` is used by the adapter factory to resolve clients via the `cq:graphqlClient` property set on any JCR node. When this is set on a resource or the resource ancestors, one can write `GraphqlClient client = resource.adaptTo(GraphqlClient.class);`.
 
@@ -63,11 +70,12 @@ The `identifier` is used by the adapter factory to resolve clients via the `cq:g
 Starting with version `1.4.0`, the client can cache GraphQL `query` requests based on the `cacheConfigurations` parameter. This supports the configuration of multiple caches, each being identified by a name and having its own set of caching parameters. This ensures that multiple components and services using cached data can have their own caching strategy and that those will not collide, for example when one component/service starves a common cache with a very large amount of requests. On the Java side, caching is controlled by the `CachingStrategy` class that can be set in the `RequestOptions` class.
 
 Because of the limitations of the AEM OSGi configuration console when defining multiple parameters with multiple values, each cache configuration entry must be specified with the following format:
-* `NAME:ENABLE:MAXSIZE:TIMEOUT` like for example `mycache:true:1000:60` where each attribute is defined as:
-  * NAME (String) : the name of the cache
-  * ENABLE (true|false) : enables or disables that cache entry (useful to temporarily disable a cache)
-  * MAXSIZE (Integer) : the maximum size of the cache in number of entries
-  * TIMEOUT (Integer) : the timeout for each cache entry, in seconds
+
+-   `NAME:ENABLE:MAXSIZE:TIMEOUT` like for example `mycache:true:1000:60` where each attribute is defined as:
+    -   NAME (String) : the name of the cache
+    -   ENABLE (true|false) : enables or disables that cache entry (useful to temporarily disable a cache)
+    -   MAXSIZE (Integer) : the maximum size of the cache in number of entries
+    -   TIMEOUT (Integer) : the timeout for each cache entry, in seconds
 
 Note that even if it is enabled, a cache is only used if the `RequestOptions` set by the caller component/service defines the cache name and explicitly sets the `DataFetchingPolicy` to `CACHE_FIRST`. This ensures that the behavior of the client is backwards compatible (= caching is skipped by default). In addition, a caller can explicitly set the `DataFetchingPolicy` to `NETWORK_ONLY` to skip caching programmatically, even if caching is enabled in the OSGi configuration.
 
@@ -76,15 +84,17 @@ Note that even if it is enabled, a cache is only used if the `RequestOptions` se
 Releases are triggered by manually running `mvn release:prepare release:clean` on the `master` branch. This automatically pushes a commit with a release git tag like `graphql-client-x.y.z.` which triggers a dedicated `CircleCI` build that performs the deployment of the artifact to Maven Central.
 
 ## Code Formatting
+
 You can find the code formatting rules in the `eclipse-formatter.xml` file. The code formatting is automatically checked for each build. To automatically format your code, please run:
+
 ```bash
 mvn clean install -Pformat-code
 ```
 
 ### Contributing
- 
+
 Contributions are welcomed! Read the [Contributing Guide](.github/CONTRIBUTING.md) for more information.
- 
+
 ### Licensing
- 
+
 This project is licensed under the Apache V2 License. See [LICENSE](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,17 @@ This installs everything by default to `localhost:4502` without any context path
 
 ### Prerequisites
 
-The GraphQL client needs a service user to read the configurations, so consumers must provide one or more user mappings. The minimum privilege matrix is the following:
+The GraphQL client needs a service user to read the configurations, so consumers must provide one or more user mappings. The minimum privilege matrix for the service user(s) is the following:
 
 | **Path**     | **Privilege** |
 | -------------- | --------------- |
 | /conf          | jcr:read      |
 | /content       | jcr:read      |
 | /libs/settings | jcr:read       |
+
+You can either use one service user or an aggregate of several users, each with its own privilege set.
+
+### Using the library
 
 To use this library in your project, just add the following maven dependency to your project and install the bundle in your AEM instance:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ This installs everything by default to `localhost:4502` without any context path
 
 ## Using the GraphQL client
 
+### Prerequisites
+
+The GraphQL client needs a service user to read the configurations, so consumers must provide one or more user mappings. The minimum privilege matrix is the following:
+
+| **Path**     | **Privilege** |
+| -------------- | --------------- |
+| /conf          | jcr:read      |
+| /content       | jcr:read      |
+| /libs/settings | jcr:read       |
+
 To use this library in your project, just add the following maven dependency to your project and install the bundle in your AEM instance:
 
 ```xml
@@ -32,6 +42,8 @@ To use this library in your project, just add the following maven dependency to 
 ```
 
 You'll then have to setup and configure the client in your AEM instance.
+
+
 
 ## OSGi configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -396,12 +396,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.sling-mock</artifactId>
-            <version>2.2.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
             <version>0.8.3</version>

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
@@ -14,7 +14,9 @@
 
 package com.adobe.cq.commerce.graphql.client.impl;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -109,7 +111,12 @@ public class GraphqlClientAdapterFactoryTest {
         // Ensure that adapter returns null if not adapted from a resource
         Object target = factory.getAdapter(factory, Object.class);
         Assert.assertNull(target);
-
+        ResourceResolverFactory resourceResolverFactory = GraphqlAemContext.mockResourceResolverFactory(context);
+        try {
+            FieldUtils.writeField(factory, "resolverFactory", resourceResolverFactory, true);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
         // Ensure that adapter returns null if not adapting to a GraphQL client
         Resource res = context.resourceResolver().getResource("/content/test");
         target = factory.getAdapter(res, Object.class);


### PR DESCRIPTION
## Description

Use a service resource resolver for the GraphQL client adapter factory. The consumer must bring their own service users which they need to have `jcr:read` privileges on `/conf`, `/content`, `/libs/settings`

## Related Issue

CIF-1429

## Motivation and Context

On the Cloud AEM publish instance, the "anonymous" user doesn't have read access on the `/conf` path. 

## How Has This Been Tested?

Functional testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
