### PR TITLE
Support HTTP protocol

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfiguration.java
@@ -28,6 +28,7 @@ public @interface GraphqlClientConfiguration {
 
     int MAX_HTTP_CONNECTIONS_DEFAULT = 20;
     boolean ACCEPT_SELF_SIGNED_CERTIFICATES = false;
+    boolean ALLOW_HTTP_PROTOCOL = false;
 
     int DEFAULT_CONNECTION_TIMEOUT = 5000;
     int DEFAULT_SOCKET_TIMEOUT = 5000;
@@ -59,6 +60,12 @@ public @interface GraphqlClientConfiguration {
         description = "Enable insecure/developer mode to accept self-signed SSL certificates. Do NOT activate on production systems!",
         type = AttributeType.BOOLEAN)
     boolean acceptSelfSignedCertificates() default ACCEPT_SELF_SIGNED_CERTIFICATES;
+
+    @AttributeDefinition(
+        name = "Allow HTTP communication",
+        description = "Enable insecure/developer mode to allow communication via HTTP. Do NOT activate on production systems!",
+        type = AttributeType.BOOLEAN)
+    boolean allowHttpProtocol() default ALLOW_HTTP_PROTOCOL;
 
     @AttributeDefinition(
         name = "Max HTTP connections",

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
@@ -15,7 +15,6 @@
 package com.adobe.cq.commerce.graphql.client.impl;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
@@ -23,47 +22,32 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHeaders;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
+import com.adobe.cq.commerce.graphql.client.impl.MockServerHelper.Data;
+import com.adobe.cq.commerce.graphql.client.impl.MockServerHelper.Error;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockserver.model.HttpStatusCode.INTERNAL_SERVER_ERROR_500;
 
 public class ConcurrencyTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrencyTest.class);
     private static final int THREAD_COUNT = GraphqlClientConfiguration.MAX_HTTP_CONNECTIONS_DEFAULT * 2;
 
-    private static ClientAndServer mockServer;
-
-    private static class Data {
-        String text;
-        Integer count;
-    }
-
-    private static class Error {
-        String message;
-    }
+    private static MockServerHelper mockServer;
 
     private GraphqlClientImpl graphqlClient;
-    private GraphqlRequest dummy = new GraphqlRequest("{dummy}");
 
     @BeforeClass
     public static void initServer() throws IOException {
-        mockServer = ClientAndServer.startClientAndServer();
-        LOGGER.info("Started HTTP mock server on port {}", mockServer.getLocalPort());
+        mockServer = new MockServerHelper();
     }
 
     @AfterClass
@@ -83,20 +67,12 @@ public class ConcurrencyTest {
 
     @Test(timeout = 15000)
     public void testConcurrencyWithResponses() throws Exception {
-        String json = getResource("sample-graphql-response.json");
-        mockServer.reset()
-            .when(HttpRequest.request().withPath("/graphql"))
-            .respond(HttpResponse
-                .response()
-                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-                .withHeader(HttpHeaders.CONNECTION, "keep-alive")
-                .withBody(json)
-                .withDelay(TimeUnit.MILLISECONDS, 50));
+        mockServer.resetWithSampleResponse();
 
         ExecutorService service = Executors.newFixedThreadPool(THREAD_COUNT);
         Collection<Future<GraphqlResponse<Data, Error>>> futures = new ArrayList<>(THREAD_COUNT);
         for (int t = 0; t < THREAD_COUNT; t++) {
-            futures.add(service.submit(() -> graphqlClient.execute(dummy, Data.class, Error.class)));
+            futures.add(service.submit(() -> mockServer.executeGraphqlClientDummyRequest(graphqlClient)));
         }
 
         Collection<GraphqlResponse<Data, Error>> responses = new ArrayList<>();
@@ -106,13 +82,7 @@ public class ConcurrencyTest {
 
         assertEquals(THREAD_COUNT, responses.size());
         for (GraphqlResponse<Data, Error> response : responses) {
-            assertEquals("Some text", response.getData().text);
-            assertEquals(42, response.getData().count.intValue());
-
-            // Check the response errors
-            assertEquals(1, response.getErrors().size());
-            Error error = response.getErrors().get(0);
-            assertEquals("Error message", error.message);
+            mockServer.validateSampleResponse(response);
         }
     }
 
@@ -122,23 +92,19 @@ public class ConcurrencyTest {
         // If the error messages are not consumed by the client, this test will time out
         // because all threads from the connection pool will stay stuck
 
-        HttpResponse error = new HttpResponse()
-            .withStatusCode(INTERNAL_SERVER_ERROR_500.code())
+        HttpResponse error = new HttpResponse().withStatusCode(INTERNAL_SERVER_ERROR_500.code())
             .withReasonPhrase(INTERNAL_SERVER_ERROR_500.reasonPhrase())
             .withHeader(HttpHeaders.CONNECTION, "keep-alive")
-            .withBody("Dummy content that MUST be consumed by the client")
-            .withDelay(TimeUnit.MILLISECONDS, 50);
+            .withBody("Dummy content that MUST be consumed by the client").withDelay(TimeUnit.MILLISECONDS, 50);
 
-        mockServer.reset()
-            .when(HttpRequest.request().withPath("/graphql"))
-            .respond(error);
+        mockServer.reset().when(HttpRequest.request().withPath("/graphql")).respond(error);
 
         ExecutorService service = Executors.newFixedThreadPool(THREAD_COUNT);
         Collection<Future<GraphqlResponse<Data, Error>>> futures = new ArrayList<>(THREAD_COUNT);
         for (int t = 0; t < THREAD_COUNT; t++) {
             futures.add(service.submit(() -> {
                 try {
-                    return graphqlClient.execute(dummy, Data.class, Error.class);
+                    return mockServer.executeGraphqlClientDummyRequest(graphqlClient);
                 } catch (Exception e) {
                     return null;
                 }
@@ -158,22 +124,19 @@ public class ConcurrencyTest {
         // The timeout of the HTTP client is much smaller than the timeout we define in the mock server
         // so we expect that all connection attemps will properly time out before the test itself times out
 
-        HttpResponse error = new HttpResponse()
-            .withStatusCode(INTERNAL_SERVER_ERROR_500.code())
+        HttpResponse error = new HttpResponse().withStatusCode(INTERNAL_SERVER_ERROR_500.code())
             .withReasonPhrase(INTERNAL_SERVER_ERROR_500.reasonPhrase())
-            .withHeader(HttpHeaders.CONNECTION, "keep-alive")
-            .withDelay(TimeUnit.SECONDS, 60); // Must be higher than test timeout
+            .withHeader(HttpHeaders.CONNECTION, "keep-alive").withDelay(TimeUnit.SECONDS, 60); // Must be higher
+                                                                                               // than test timeout
 
-        mockServer.reset()
-            .when(HttpRequest.request().withPath("/graphql"))
-            .respond(error);
+        mockServer.reset().when(HttpRequest.request().withPath("/graphql")).respond(error);
 
         ExecutorService service = Executors.newFixedThreadPool(THREAD_COUNT);
         Collection<Future<GraphqlResponse<Data, Error>>> futures = new ArrayList<>(THREAD_COUNT);
         for (int t = 0; t < THREAD_COUNT; t++) {
             futures.add(service.submit(() -> {
                 try {
-                    return graphqlClient.execute(dummy, Data.class, Error.class);
+                    return mockServer.executeGraphqlClientDummyRequest(graphqlClient);
                 } catch (Exception e) {
                     return null;
                 }
@@ -187,7 +150,4 @@ public class ConcurrencyTest {
         assertEquals(THREAD_COUNT, responses.size());
     }
 
-    private static String getResource(String filename) throws IOException {
-        return IOUtils.toString(ConcurrencyTest.class.getClassLoader().getResourceAsStream(filename), StandardCharsets.UTF_8);
-    }
 }

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
@@ -23,6 +23,7 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
     public static final String URL = "https://hostname/graphql";
     private String url;
     private Boolean acceptSelfSignedCertificates;
+    private Boolean allowHttpProtocol;
     private String[] httpHeaders;
     private String[] cacheConfigurations;
 
@@ -45,6 +46,12 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
     public boolean acceptSelfSignedCertificates() {
         return acceptSelfSignedCertificates != null ? acceptSelfSignedCertificates
             : GraphqlClientConfiguration.ACCEPT_SELF_SIGNED_CERTIFICATES;
+    }
+
+    @Override
+    public boolean allowHttpProtocol() {
+        return allowHttpProtocol != null ? allowHttpProtocol
+            : GraphqlClientConfiguration.ALLOW_HTTP_PROTOCOL;
     }
 
     @Override
@@ -88,6 +95,10 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
 
     public void setAcceptSelfSignedCertificates(boolean acceptSelfSignedCertificates) {
         this.acceptSelfSignedCertificates = acceptSelfSignedCertificates;
+    }
+
+    public void setAllowHttpProtocol(Boolean allowHttpProtocol) {
+        this.allowHttpProtocol = allowHttpProtocol;
     }
 
     public void setHttpHeaders(String... httpHeaders) {

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockServerHelper.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockServerHelper.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ *
+ *    Copyright 2020 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.graphql.client.impl;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHeaders;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.commerce.graphql.client.GraphqlClient;
+import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
+import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
+
+import static org.junit.Assert.assertEquals;
+
+public class MockServerHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MockServerHelper.class);
+
+    private final ClientAndServer mockServer;
+    private final GraphqlRequest dummy = new GraphqlRequest("{dummy}");
+
+    public MockServerHelper() {
+        mockServer = ClientAndServer.startClientAndServer();
+        LOGGER.info("Started HTTP mock server on port {}", mockServer.getLocalPort());
+    }
+
+    public GraphqlResponse<Data, Error> executeGraphqlClientDummyRequest(GraphqlClient graphqlClient)
+        throws IOException {
+        return graphqlClient.execute(dummy, Data.class, Error.class);
+    }
+
+    public void resetWithSampleResponse() {
+        String json = getResource("sample-graphql-response.json");
+        mockServer.reset().when(HttpRequest.request().withPath("/graphql"))
+            .respond(HttpResponse.response().withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .withHeader(HttpHeaders.CONNECTION, "keep-alive").withBody(json)
+                .withDelay(TimeUnit.MILLISECONDS, 50));
+    }
+
+    public void validateSampleResponse(GraphqlResponse<Data, Error> response) throws IOException {
+        assertEquals("Some text", response.getData().text);
+        assertEquals(42, response.getData().count.intValue());
+
+        // Check the response errors
+        assertEquals(1, response.getErrors().size());
+        Error error = response.getErrors().get(0);
+        assertEquals("Error message", error.message);
+    }
+
+    private static String getResource(String filename) {
+        try {
+            return IOUtils.toString(MockServerHelper.class.getClassLoader().getResourceAsStream(filename),
+                StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public MockServerClient reset() {
+        return mockServer.reset();
+    }
+
+    public void stop() {
+        mockServer.stop();
+    }
+
+    public Integer getLocalPort() {
+        return mockServer.getLocalPort();
+    }
+
+    public static class Data {
+        String text;
+        Integer count;
+    }
+
+    public static class Error {
+        String message;
+    }
+
+}

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ProtocolTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ProtocolTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ *
+ *    Copyright 2020 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.graphql.client.impl;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
+import com.adobe.cq.commerce.graphql.client.impl.MockServerHelper.Data;
+import com.adobe.cq.commerce.graphql.client.impl.MockServerHelper.Error;
+
+public class ProtocolTest {
+
+    private static MockServerHelper mockServer;
+
+    @BeforeClass
+    public static void initServer() {
+        mockServer = new MockServerHelper();
+        mockServer.resetWithSampleResponse();
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        mockServer.stop();
+    }
+
+    @Test(timeout = 15000)
+    public void testSimpleRequest_HTTPS() throws Exception {
+        MockGraphqlClientConfiguration config = new MockGraphqlClientConfiguration();
+        config.setUrl("https://localhost:" + mockServer.getLocalPort() + "/graphql");
+        config.setAcceptSelfSignedCertificates(true);
+
+        GraphqlClientImpl graphqlClient = new GraphqlClientImpl();
+        graphqlClient.activate(config);
+
+        GraphqlResponse<Data, Error> response = mockServer.executeGraphqlClientDummyRequest(graphqlClient);
+        mockServer.validateSampleResponse(response);
+    }
+
+    /**
+     * Ensure HTTP communication is by default not allowed.
+     */
+    @Test(expected = RuntimeException.class)
+    public void testSimpleRequest_HTTP_Disallowed() throws Exception {
+        MockGraphqlClientConfiguration config = new MockGraphqlClientConfiguration();
+        config.setUrl("http://localhost:" + mockServer.getLocalPort() + "/graphql");
+
+        GraphqlClientImpl graphqlClient = new GraphqlClientImpl();
+        graphqlClient.activate(config);
+
+        mockServer.executeGraphqlClientDummyRequest(graphqlClient);
+    }
+
+    /**
+     * HTTP communcation should work if enabled via configuration.
+     */
+    @Test(timeout = 15000)
+    public void testSimpleRequest_HTTP_Allowed() throws Exception {
+        MockGraphqlClientConfiguration config = new MockGraphqlClientConfiguration();
+        config.setUrl("http://localhost:" + mockServer.getLocalPort() + "/graphql");
+        config.setAllowHttpProtocol(true);
+
+        GraphqlClientImpl graphqlClient = new GraphqlClientImpl();
+        graphqlClient.activate(config);
+
+        GraphqlResponse<Data, Error> response = mockServer.executeGraphqlClientDummyRequest(graphqlClient);
+        mockServer.validateSampleResponse(response);
+    }
+
+}


### PR DESCRIPTION
Surprisingly the current implementation only supports HTTPs protocol, no HTTP protocol (HTTP client throws an error if HTTP protocl is used). For local development it's useful to also support HTTP.

This PR adds support for HTTP protocol including test coverage (with some test refactoring to re-use code from ConcurrencyTest).