### PR TITLE
Add package-info to com.adobe.cq.commerce.graphql.client

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ *
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+@org.osgi.annotation.versioning.Version("1.6.0")
+package com.adobe.cq.commerce.graphql.client;


### PR DESCRIPTION
OSGi bundles exporting java packages should always define package versions, which should only be changed when the interfaces are changed (baseline check ensures proper semantic versioning).

This bundle automatically uses the bundle version as package version which is bad practice - the PR adds a version definition for the package.