### PR TITLE
CIF-1649 - Expose complete GraphqlClientConfiguration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.commerce.cif</groupId>
     <artifactId>graphql-client</artifactId>
-    <version>1.6.2-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Generic GraphQL client</name>

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClient.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClient.java
@@ -37,6 +37,13 @@ public interface GraphqlClient {
     public String getGraphQLEndpoint();
 
     /**
+     * Returns the complete configuration of the GraphQL client.
+     *
+     * @return GraphQL client configuration.
+     */
+    public GraphqlClientConfiguration getConfiguration();
+
+    /**
      * Executes the given GraphQL request and deserializes the response data based on the types T and U.
      * The type T is used to deserialize the 'data' object of the GraphQL response, and the type U is used
      * to deserialize the 'errors' array of the GraphQL response.

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
@@ -12,13 +12,11 @@
  *
  ******************************************************************************/
 
-package com.adobe.cq.commerce.graphql.client.impl;
+package com.adobe.cq.commerce.graphql.client;
 
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.AttributeType;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
-
-import com.adobe.cq.commerce.graphql.client.HttpMethod;
 
 @ObjectClassDefinition(name = "CIF GraphQL Client Configuration Factory")
 public @interface GraphqlClientConfiguration {

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactory.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactory.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
+import com.adobe.cq.commerce.graphql.client.GraphqlClientConfiguration;
 import com.day.cq.commons.inherit.ComponentInheritanceValueMap;
 import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
 import com.day.cq.commons.inherit.InheritanceValueMap;

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
@@ -12,5 +12,5 @@
  *
  ******************************************************************************/
 
-@org.osgi.annotation.versioning.Version("1.6.0")
+@org.osgi.annotation.versioning.Version("1.7.0")
 package com.adobe.cq.commerce.graphql.client;

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
+import com.adobe.cq.commerce.graphql.client.GraphqlClientConfiguration;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.graphql.client.impl.MockServerHelper.Data;
 import com.adobe.cq.commerce.graphql.client.impl.MockServerHelper.Error;

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.adobe.cq.commerce.graphql.client.GraphqlClientConfiguration;
 import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.graphql.client.HttpMethod;

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -63,17 +63,19 @@ public class GraphqlClientImplTest {
 
     private GraphqlClientImpl graphqlClient;
     private GraphqlRequest dummy = new GraphqlRequest("{dummy}");
+    private MockGraphqlClientConfiguration mockConfig;
 
     @Before
     public void setUp() throws Exception {
         graphqlClient = new GraphqlClientImpl();
 
-        MockGraphqlClientConfiguration config = new MockGraphqlClientConfiguration();
+        mockConfig = new MockGraphqlClientConfiguration();
         // Add three test headers, one with extra white space around " : " to make sure we properly trim spaces, and one empty header
-        config.setHttpHeaders(HttpHeaders.AUTHORIZATION + ":" + AUTH_HEADER_VALUE, HttpHeaders.CACHE_CONTROL + " : " + CACHE_HEADER_VALUE,
+        mockConfig.setHttpHeaders(HttpHeaders.AUTHORIZATION + ":" + AUTH_HEADER_VALUE, HttpHeaders.CACHE_CONTROL + " : "
+            + CACHE_HEADER_VALUE,
             "");
 
-        graphqlClient.activate(config);
+        graphqlClient.activate(mockConfig);
         graphqlClient.client = Mockito.mock(HttpClient.class);
     }
 
@@ -242,5 +244,11 @@ public class GraphqlClientImplTest {
     public void testGetGraphQLEndpoint() throws Exception {
         String endpointURL = graphqlClient.getGraphQLEndpoint();
         assertEquals(MockGraphqlClientConfiguration.URL, endpointURL);
+    }
+
+    @Test
+    public void testGetConfiguration() {
+        GraphqlClientConfiguration configuration = graphqlClient.getConfiguration();
+        assertEquals(mockConfig, configuration);
     }
 }

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
@@ -16,6 +16,7 @@ package com.adobe.cq.commerce.graphql.client.impl;
 
 import java.lang.annotation.Annotation;
 
+import com.adobe.cq.commerce.graphql.client.GraphqlClientConfiguration;
 import com.adobe.cq.commerce.graphql.client.HttpMethod;
 
 public class MockGraphqlClientConfiguration implements Annotation, GraphqlClientConfiguration {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Added new `getConfiguration` method which returns the full `GraphqlClientConfiguration` object.
* Motivation behind the change is to make certain configurations (headers and HTTP method) accessible for client-side components.
* Bumped version to `1.7.0-SNAPSHOT`.
* Updated unit tests.

## How Has This Been Tested?

* Unit tests
* Manual tests with CIF add-on

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
