### PR TITLE
CIF-1801 - GraphQL client does not properly UTF-8 encode POST body

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -258,7 +258,7 @@ public class GraphqlClientImpl implements GraphqlClient {
                 rb.addParameter("variables", json);
             }
         } else {
-            rb.setEntity(new StringEntity(gson.toJson(request)));
+            rb.setEntity(new StringEntity(gson.toJson(request), StandardCharsets.UTF_8.name()));
         }
 
         if (configuration.httpHeaders() != null) {

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -62,7 +62,7 @@ public class GraphqlClientImplTest {
     }
 
     private GraphqlClientImpl graphqlClient;
-    private GraphqlRequest dummy = new GraphqlRequest("{dummy}");
+    private GraphqlRequest dummy = new GraphqlRequest("{dummy-é}"); // with accent to check UTF-8 character
     private MockGraphqlClientConfiguration mockConfig;
 
     @Before

--- a/src/test/resources/sample-graphql-request.json
+++ b/src/test/resources/sample-graphql-request.json
@@ -1,1 +1,1 @@
-{"query":"{dummy}","operationName":"customOperation","variables":{"variableName":"variableValue"}}
+{"query":"{dummy-é}","operationName":"customOperation","variables":{"variableName":"variableValue"}}


### PR DESCRIPTION
Note that one unit test would fail with the extra `-é` text added to the test query, so adding this will prevent any future regression.

Fixes #21. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
