### PR TITLE
CIF-2157: add metrics for request duration and error count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+*.iml
 .classpath
 .metadata
 .project

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
 
     <build>
         <plugins>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -310,8 +309,8 @@
 
             <plugin>
                 <groupId>org.apache.sling</groupId>
-                <artifactId>maven-sling-plugin</artifactId>
-                <version>2.1.0</version>
+                <artifactId>sling-maven-plugin</artifactId>
+                <version>2.4.2</version>
                 <configuration>
                     <slingUrl>http://${aem.host}:${aem.port}${aem.contextPath}/system/console</slingUrl>
                 </configuration>
@@ -418,6 +417,28 @@
     </dependencies>
 
     <profiles>
+        <profile>
+            <id>autoInstallBundle</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>sling-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>install-bundle</id>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <!-- GPG Signature on release -->
         <profile>
             <id>release-sign-artifacts</id>

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -182,7 +182,7 @@ public class GraphqlClientImpl implements GraphqlClient {
         try {
             httpResponse = client.execute(buildRequest(request, options));
         } catch (Exception e) {
-            metrics.incrementRequestErrorCount();
+            metrics.incrementRequestErrors();
             throw new RuntimeException("Failed to send GraphQL request", e);
         }
 
@@ -194,7 +194,7 @@ public class GraphqlClientImpl implements GraphqlClient {
                 json = EntityUtils.toString(entity, StandardCharsets.UTF_8);
                 stopTimer.run();
             } catch (Exception e) {
-                metrics.incrementRequestErrorCount();
+                metrics.incrementRequestErrors();
                 throw new RuntimeException("Failed to read HTTP response content", e);
             }
 
@@ -212,7 +212,7 @@ public class GraphqlClientImpl implements GraphqlClient {
             return response;
         } else {
             EntityUtils.consumeQuietly(httpResponse.getEntity());
-            metrics.incrementRequestErrorCount(statusLine.getStatusCode());
+            metrics.incrementRequestErrors(statusLine.getStatusCode());
             throw new RuntimeException("GraphQL query failed with response code " + statusLine.getStatusCode());
         }
     }

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetrics.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetrics.java
@@ -16,10 +16,13 @@ package com.adobe.cq.commerce.graphql.client.impl;
 import com.codahale.metrics.Timer;
 
 /**
- * This interface provides a facade of the metrics tracked by the {@link GraphqlClientImpl}. With {@link GraphqlClientMetrics#NOOP} it provides a
- * no-operation implementation for environments that don't have cif metrics enabled.
+ * This interface provides a facade of the metrics tracked by the {@link GraphqlClientImpl}. With {@link GraphqlClientMetrics#NOOP} it
+ * provides a no-operation implementation for environments that don't have cif metrics enabled.
  */
 interface GraphqlClientMetrics {
+
+    String REQUEST_DURATION_METRIC = "graphql-client.request.duration";
+    String REQUEST_ERROR_COUNT_METRIC = "graphql-client.request.errors";
 
     GraphqlClientMetrics NOOP = new GraphqlClientMetrics() {
         @Override public Runnable startRequestDurationTimer() {
@@ -28,11 +31,11 @@ interface GraphqlClientMetrics {
             };
         }
 
-        @Override public void incrementRequestErrorCount() {
+        @Override public void incrementRequestErrors() {
             // do nothing
         }
 
-        @Override public void incrementRequestErrorCount(int status) {
+        @Override public void incrementRequestErrors(int status) {
             // do nothing
         }
     };
@@ -48,13 +51,13 @@ interface GraphqlClientMetrics {
     /**
      * Increments the generic request error count.
      */
-    void incrementRequestErrorCount();
+    void incrementRequestErrors();
 
     /**
      * Increments the specific request error count for the given status.
      *
      * @param
      */
-    void incrementRequestErrorCount(int status);
+    void incrementRequestErrors(int status);
 
 }

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetrics.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetrics.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ *
+ *    Copyright 2021 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+package com.adobe.cq.commerce.graphql.client.impl;
+
+import com.codahale.metrics.Timer;
+
+/**
+ * This interface provides a facade of the metrics tracked by the {@link GraphqlClientImpl}. With {@link GraphqlClientMetrics#NOOP} it provides a
+ * no-operation implementation for environments that don't have cif metrics enabled.
+ */
+interface GraphqlClientMetrics {
+
+    GraphqlClientMetrics NOOP = new GraphqlClientMetrics() {
+        @Override public Runnable startRequestDurationTimer() {
+            return () -> {
+                // do nothing
+            };
+        }
+
+        @Override public void incrementRequestErrorCount() {
+            // do nothing
+        }
+
+        @Override public void incrementRequestErrorCount(int status) {
+            // do nothing
+        }
+    };
+
+    /**
+     * Starts a request duration timer. The returned {@link Runnable} wraps the {@link Timer.Context#close()} and must be called in
+     * order to add the measurement to the metric.
+     *
+     * @return
+     */
+    Runnable startRequestDurationTimer();
+
+    /**
+     * Increments the generic request error count.
+     */
+    void incrementRequestErrorCount();
+
+    /**
+     * Increments the specific request error count for the given status.
+     *
+     * @param
+     */
+    void incrementRequestErrorCount(int status);
+
+}

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetricsImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetricsImpl.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ *
+ *    Copyright 2021 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+package com.adobe.cq.commerce.graphql.client.impl;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import com.adobe.cq.commerce.graphql.client.GraphqlClientConfiguration;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+
+class GraphqlClientMetricsImpl implements GraphqlClientMetrics {
+
+    private static final String REQUEST_DURATION_METRIC = "graphql-client.request.duration";
+    private static final String REQUEST_ERROR_COUNT_METRIC = "graphql-client.request.error-count";
+    private static final String METRIC_LABEL_ENDPOINT = "endpoint";
+    private static final String METRIC_LABEL_STATUS_CODE = "status";
+
+    private final MetricRegistry metrics;
+    private final GraphqlClientConfiguration configuration;
+    private final Timer requestDurationTimer;
+    private final ConcurrentMap<Integer, Counter> requestErrorCounters;
+
+    GraphqlClientMetricsImpl(MetricRegistry metrics, GraphqlClientConfiguration configuration) {
+        this.metrics = metrics;
+        this.configuration = configuration;
+        this.requestDurationTimer = metrics.timer(REQUEST_DURATION_METRIC + ";endpoint=" + configuration.url());
+        this.requestErrorCounters = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public Runnable startRequestDurationTimer() {
+        return requestDurationTimer.time()::close;
+    }
+
+    @Override
+    public void incrementRequestErrorCount() {
+        incrementRequestErrorCount(0);
+    }
+
+    @Override
+    public void incrementRequestErrorCount(int status) {
+        requestErrorCounters.computeIfAbsent(status, k -> {
+            StringBuilder name = new StringBuilder();
+            name.append(REQUEST_ERROR_COUNT_METRIC);
+            name.append(';').append(METRIC_LABEL_ENDPOINT).append('=').append(configuration.url());
+            if (status > 0) {
+                name.append(';').append(METRIC_LABEL_STATUS_CODE).append('=').append(status);
+            }
+            return metrics.counter(name.toString());
+        }).inc();
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetricsImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetricsImpl.java
@@ -23,8 +23,6 @@ import com.codahale.metrics.Timer;
 
 class GraphqlClientMetricsImpl implements GraphqlClientMetrics {
 
-    private static final String REQUEST_DURATION_METRIC = "graphql-client.request.duration";
-    private static final String REQUEST_ERROR_COUNT_METRIC = "graphql-client.request.error-count";
     private static final String METRIC_LABEL_ENDPOINT = "endpoint";
     private static final String METRIC_LABEL_STATUS_CODE = "status";
 
@@ -46,12 +44,12 @@ class GraphqlClientMetricsImpl implements GraphqlClientMetrics {
     }
 
     @Override
-    public void incrementRequestErrorCount() {
-        incrementRequestErrorCount(0);
+    public void incrementRequestErrors() {
+        incrementRequestErrors(0);
     }
 
     @Override
-    public void incrementRequestErrorCount(int status) {
+    public void incrementRequestErrors(int status) {
         requestErrorCounters.computeIfAbsent(status, k -> {
             StringBuilder name = new StringBuilder();
             name.append(REQUEST_ERROR_COUNT_METRIC);

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlAemContext.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlAemContext.java
@@ -14,6 +14,7 @@
 
 package com.adobe.cq.commerce.graphql.client.impl;
 
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Map;
@@ -37,6 +38,10 @@ public final class GraphqlAemContext {
     public static GraphqlClientAdapterFactory adapterFactory;
 
     private GraphqlAemContext() {}
+
+    public static AemContext createContext() {
+        return createContext(Collections.emptyMap());
+    }
 
     public static AemContext createContext(Map<String, String> contentPaths) {
         GraphqlAemContext.adapterFactory = new GraphqlClientAdapterFactory();

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class GraphqlClientImplMetricsTest {
 
@@ -52,12 +51,11 @@ public class GraphqlClientImplMetricsTest {
 
     @Before
     public void setUp() throws Exception {
+        mockConfig.setUrl("http://foo.bar/api");
         aemContext.registerService(MetricRegistry.class, metricRegistry, "name", "cif");
         aemContext.registerInjectActivateService(graphqlClient);
         graphqlClient.activate(mockConfig);
         graphqlClient.client = mock(HttpClient.class);
-
-        mockConfig.setUrl("http://foo.bar/api");
     }
 
     @Test

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.graphql.client.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import io.wcm.testing.mock.aem.junit.AemContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GraphqlClientImplMetricsTest {
+
+    @Rule
+    public final AemContext aemContext = GraphqlAemContext.createContext();
+    private final MetricRegistry metricRegistry = new MetricRegistry();
+    private final GraphqlClientImpl graphqlClient = new GraphqlClientImpl();
+    private final GraphqlRequest dummy = new GraphqlRequest("{dummy-é}"); // with accent to check UTF-8 character
+    private final MockGraphqlClientConfiguration mockConfig = new MockGraphqlClientConfiguration();
+
+    private static class Data {}
+
+    private static class Error {}
+
+    @Before
+    public void setUp() throws Exception {
+        aemContext.registerService(MetricRegistry.class, metricRegistry, "name", "cif");
+        aemContext.registerInjectActivateService(graphqlClient);
+        graphqlClient.activate(mockConfig);
+        graphqlClient.client = mock(HttpClient.class);
+
+        mockConfig.setUrl("http://foo.bar/api");
+    }
+
+    @Test
+    public void testRequestDurationTracked() throws IOException {
+        // given
+        TestUtils.setupHttpResponse("sample-graphql-response.json", graphqlClient.client, HttpStatus.SC_OK);
+
+        // when
+        graphqlClient.execute(dummy, Data.class, Error.class);
+
+        // then
+        Timer timer = metricRegistry.getTimers().get("graphql-client.request.duration;endpoint=http://foo.bar/api");
+        assertNotNull(timer);
+        assertEquals(1, timer.getCount());
+    }
+
+    @Test
+    public void testRequestDurationNotTrackedOnClientError() throws IOException {
+        // given
+        doThrow(new IOException()).when(graphqlClient.client).execute(any());
+
+        // when
+        try {
+            graphqlClient.execute(dummy, Data.class, Error.class);
+            fail();
+        } catch (RuntimeException ex) {
+            // expected
+        }
+
+        // then
+        Timer timer = metricRegistry.getTimers().get("graphql-client.request.duration;endpoint=http://foo.bar/api");
+        assertNotNull(timer);
+        assertEquals(0, timer.getCount());
+        Counter counter = metricRegistry.getCounters().get("graphql-client.request.error-count;endpoint=http://foo.bar/api");
+        assertNotNull(counter);
+        assertEquals(1, counter.getCount());
+    }
+
+    @Test
+    public void testRequestDurationNotTrackedOnEntityLoadError() throws IOException {
+        // given
+        InputStream is = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException();
+            }
+        };
+        TestUtils.setupHttpResponse(is, graphqlClient.client, HttpStatus.SC_OK);
+
+        // when
+        try {
+            graphqlClient.execute(dummy, Data.class, Error.class);
+            fail();
+        } catch (RuntimeException ex) {
+            // expected
+        }
+
+        // then
+        Timer timer = metricRegistry.getTimers().get("graphql-client.request.duration;endpoint=http://foo.bar/api");
+        assertNotNull(timer);
+        assertEquals(0, timer.getCount());
+        Counter counter = metricRegistry.getCounters().get("graphql-client.request.error-count;endpoint=http://foo.bar/api");
+        assertNotNull(counter);
+        assertEquals(1, counter.getCount());
+    }
+
+    @Test
+    public void testErrorCodeTrackedWithStatus() throws IOException {
+        // given
+        TestUtils.setupHttpResponse(mock(InputStream.class), graphqlClient.client, HttpStatus.SC_INTERNAL_SERVER_ERROR);
+
+        // when
+        try {
+            graphqlClient.execute(dummy, Data.class, Error.class);
+            fail();
+        } catch (RuntimeException ex) {
+            // expected
+        }
+
+        // then
+        Counter counter = metricRegistry.getCounters().get("graphql-client.request.error-count;endpoint=http://foo.bar/api;status=500");
+        assertNotNull(counter);
+        assertEquals(1, counter.getCount());
+    }
+}

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
@@ -89,7 +89,7 @@ public class GraphqlClientImplMetricsTest {
         Timer timer = metricRegistry.getTimers().get("graphql-client.request.duration;endpoint=http://foo.bar/api");
         assertNotNull(timer);
         assertEquals(0, timer.getCount());
-        Counter counter = metricRegistry.getCounters().get("graphql-client.request.error-count;endpoint=http://foo.bar/api");
+        Counter counter = metricRegistry.getCounters().get("graphql-client.request.errors;endpoint=http://foo.bar/api");
         assertNotNull(counter);
         assertEquals(1, counter.getCount());
     }
@@ -117,7 +117,7 @@ public class GraphqlClientImplMetricsTest {
         Timer timer = metricRegistry.getTimers().get("graphql-client.request.duration;endpoint=http://foo.bar/api");
         assertNotNull(timer);
         assertEquals(0, timer.getCount());
-        Counter counter = metricRegistry.getCounters().get("graphql-client.request.error-count;endpoint=http://foo.bar/api");
+        Counter counter = metricRegistry.getCounters().get("graphql-client.request.errors;endpoint=http://foo.bar/api");
         assertNotNull(counter);
         assertEquals(1, counter.getCount());
     }
@@ -136,7 +136,7 @@ public class GraphqlClientImplMetricsTest {
         }
 
         // then
-        Counter counter = metricRegistry.getCounters().get("graphql-client.request.error-count;endpoint=http://foo.bar/api;status=500");
+        Counter counter = metricRegistry.getCounters().get("graphql-client.request.errors;endpoint=http://foo.bar/api;status=500");
         assertNotNull(counter);
         assertEquals(1, counter.getCount());
     }

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/TestUtils.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/TestUtils.java
@@ -16,6 +16,7 @@ package com.adobe.cq.commerce.graphql.client.impl;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -165,6 +166,20 @@ public class TestUtils {
         Mockito.when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);
 
         return json;
+    }
+
+    public static void setupHttpResponse(InputStream data, HttpClient httpClient, int httpCode) throws IOException {
+        HttpEntity mockedHttpEntity = Mockito.mock(HttpEntity.class);
+        HttpResponse mockedHttpResponse = Mockito.mock(HttpResponse.class);
+        StatusLine mockedStatusLine = Mockito.mock(StatusLine.class);
+
+        Mockito.when(mockedHttpEntity.getContent()).thenReturn(data);
+
+        Mockito.when(mockedHttpResponse.getEntity()).thenReturn(mockedHttpEntity);
+        Mockito.when(httpClient.execute((HttpUriRequest) Mockito.any())).thenReturn(mockedHttpResponse);
+
+        Mockito.when(mockedStatusLine.getStatusCode()).thenReturn(httpCode);
+        Mockito.when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);
     }
 
     public static void setupNullResponse(HttpClient httpClient) throws IOException {


### PR DESCRIPTION
## Description

This PR adds metrics for request duration and error count to the GraphqlClientImpl. It tracks them in context of each endpoint's url (added as endpoint label) and for the error count in the context of the status code retuned by the endpoint.

It uses the `cif` namespace, which is per default available on the latest cloud service image.

## Related Issue

CIF-2157

## Motivation and Context

Ops Readiness

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
