### PR TITLE
CIF-2179: add connection pool metrics

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetrics.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetrics.java
@@ -29,10 +29,17 @@ interface GraphqlClientMetrics {
     String CACHE_MISS_METRIC = "graphql-client.cache.misses";
     String CACHE_EVICTION_METRIC = "graphql-client.cache.evictions";
     String CACHE_USAGE_METRIC = "graphql-client.cache.usage";
+    String CONNECTION_POOL_AVAILABLE_METRIC = "graphql-client.connection-pool.available-connections";
+    String CONNECTION_POOL_PENDING_METRIC = "graphql-client.connection-pool.pending-requests";
+    String CONNECTION_POOL_USAGE_METRIC = "graphql-client.connection-pool.usage";
 
     GraphqlClientMetrics NOOP = new GraphqlClientMetrics() {
 
-        @Override public void addCacheMetric(String metric, String cacheName, Supplier<? extends Number> valueSupplier) {
+        @Override public void addConnectionPoolMetric(String metricName, Supplier<? extends Number> valueSupplier) {
+            //do nothing
+        }
+
+        @Override public void addCacheMetric(String metricName, String cacheName, Supplier<? extends Number> valueSupplier) {
             // do nothing
         }
 
@@ -52,9 +59,14 @@ interface GraphqlClientMetrics {
     };
 
     /**
+     * Adds a connection pool metric.
+     */
+    void addConnectionPoolMetric(String metricName, Supplier<? extends Number> valueSupplier);
+
+    /**
      * Adds a cache metric.
      */
-    void addCacheMetric(String metric, String cacheName, Supplier<? extends Number> valueSupplier);
+    void addCacheMetric(String metricName, String cacheName, Supplier<? extends Number> valueSupplier);
 
     /**
      * Starts a request duration timer. The returned {@link Runnable} wraps the {@link Timer.Context#close()} and must be called in

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetricsImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetricsImpl.java
@@ -53,6 +53,14 @@ class GraphqlClientMetricsImpl implements GraphqlClientMetrics, Closeable {
     }
 
     @Override
+    public void addConnectionPoolMetric(String metricName, Supplier<? extends Number> valueSupplier) {
+        String metricNameAndLabels = metricName
+            + ';' + METRIC_LABEL_IDENTIFIER + '=' + configuration.identifier();
+        metrics.gauge(metricNameAndLabels, () -> valueSupplier::get);
+        disposables.add(() -> metrics.remove(metricNameAndLabels));
+    }
+
+    @Override
     public void addCacheMetric(String metricName, String cacheName, Supplier<? extends Number> valueSupplier) {
         String metricNameAndLabels = metricName
             + ';' + METRIC_LABEL_IDENTIFIER + '=' + configuration.identifier()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Expose connection pool usage metrics of the graphql client.

This is built on top of #24

## Related Issue

CIF-2179
CIF-2180
CIF-2157

## Motivation and Context

Ops readiness

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
