### PR TITLE
CIF-2117: add warnings and exceptions for dangerous timeouts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,15 +360,15 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -414,7 +414,6 @@
             <version>5.6.1</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <profiles>

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
@@ -73,29 +73,33 @@ public @interface GraphqlClientConfiguration {
 
     @AttributeDefinition(
         name = "Http connection timeout",
-        description = "The timeout in milliseconds until a connection is established. Is the timeout longer than the default timeout a"
-            + " warning will be logged. Is it 0 or smaller the configured service will not start.",
+        description = "The timeout in milliseconds until a connection is established. Is the timeout longer than the default timeout a "
+            + "warning will be logged. Is it 0 or smaller it will fallback to the default timeout and a warning will be logged. Defaults "
+            + "to " + DEFAULT_CONNECTION_TIMEOUT,
         type = AttributeType.INTEGER)
     int connectionTimeout() default DEFAULT_CONNECTION_TIMEOUT;
 
     @AttributeDefinition(
         name = "Http socket timeout",
-        description = "The socket timeout in milliseconds, which is the timeout for waiting for data or, put differently, a maximum period"
-            + " inactivity between two consecutive data packets. Is the timeout longer than the default timeout a warning will be logged."
-            + " Is it 0 or smaller the configured service will not start.",
+        description = "The socket timeout in milliseconds, which is the timeout for waiting for data or, put differently, a maximum period "
+            + "inactivity between two consecutive data packets. Is the timeout longer than the default timeout a warning will be logged. "
+            + "Is it 0 or smaller it will fallback to the default timeout and a warning will be logged. Defaults to "
+            + DEFAULT_SOCKET_TIMEOUT,
         type = AttributeType.INTEGER)
     int socketTimeout() default DEFAULT_SOCKET_TIMEOUT;
 
     @AttributeDefinition(
         name = "Request pool timeout",
-        description = "The timeout in milliseconds used when requesting a connection from the connection manager. Is the timeout longer"
-            + " than the default timeout a warning will be logged. Is it 0 or smaller the configured service will not start.",
+        description = "The timeout in milliseconds used when requesting a connection from the connection manager. Is the timeout longer "
+            + "than the default timeout a warning will be logged. Is it 0 or smaller it will fallback to the default timeout and a "
+            + "warning will be logged. Defaults to " + DEFAULT_REQUESTPOOL_TIMEOUT,
         type = AttributeType.INTEGER)
     int requestPoolTimeout() default DEFAULT_REQUESTPOOL_TIMEOUT;
 
     @AttributeDefinition(
         name = "Default HTTP Headers",
-        description = "HTTP Headers which shall be sent with each request. Might be used for authentication. The format of each header is name:value",
+        description = "HTTP Headers which shall be sent with each request. Might be used for authentication. The format of each header is "
+            + "name:value",
         type = AttributeType.STRING)
     String[] httpHeaders();
 

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
@@ -73,19 +73,23 @@ public @interface GraphqlClientConfiguration {
 
     @AttributeDefinition(
         name = "Http connection timeout",
-        description = "The timeout in milliseconds until a connection is established. A timeout value of zero is interpreted as an infinite timeout.",
+        description = "The timeout in milliseconds until a connection is established. Is the timeout longer than the default timeout a"
+            + " warning will be logged. Is it 0 or smaller the configured service will not start.",
         type = AttributeType.INTEGER)
     int connectionTimeout() default DEFAULT_CONNECTION_TIMEOUT;
 
     @AttributeDefinition(
         name = "Http socket timeout",
-        description = "The socket timeout in milliseconds, which is the timeout for waiting for data or, put differently, a maximum period inactivity between two consecutive data packets. A timeout value of zero is interpreted as an infinite timeout.",
+        description = "The socket timeout in milliseconds, which is the timeout for waiting for data or, put differently, a maximum period"
+            + " inactivity between two consecutive data packets. Is the timeout longer than the default timeout a warning will be logged."
+            + " Is it 0 or smaller the configured service will not start.",
         type = AttributeType.INTEGER)
     int socketTimeout() default DEFAULT_SOCKET_TIMEOUT;
 
     @AttributeDefinition(
         name = "Request pool timeout",
-        description = "The timeout in milliseconds used when requesting a connection from the connection manager. A timeout value of zero is interpreted as an infinite timeout.",
+        description = "The timeout in milliseconds used when requesting a connection from the connection manager. Is the timeout longer"
+            + " than the default timeout a warning will be logged. Is it 0 or smaller the configured service will not start.",
         type = AttributeType.INTEGER)
     int requestPoolTimeout() default DEFAULT_REQUESTPOOL_TIMEOUT;
 

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfigurationImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfigurationImpl.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ *
+ *    Copyright 2021 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+package com.adobe.cq.commerce.graphql.client.impl;
+
+import java.lang.annotation.Annotation;
+
+import com.adobe.cq.commerce.graphql.client.GraphqlClientConfiguration;
+import com.adobe.cq.commerce.graphql.client.HttpMethod;
+
+/**
+ * A mutable implementation of {@link GraphqlClientConfiguration}.
+ */
+class GraphqlClientConfigurationImpl implements Annotation, GraphqlClientConfiguration {
+
+    private String url;
+    private String identifier = GraphqlClientConfiguration.DEFAULT_IDENTIFIER;
+    private HttpMethod httpMethod = HttpMethod.POST;
+    private boolean acceptSelfSignedCertificates = GraphqlClientConfiguration.ACCEPT_SELF_SIGNED_CERTIFICATES;
+    private boolean allowHttpProtocol = GraphqlClientConfiguration.ALLOW_HTTP_PROTOCOL;
+    private int maxHttpConnections = GraphqlClientConfiguration.MAX_HTTP_CONNECTIONS_DEFAULT;
+    private int connectionTimeout = GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT;
+    private int socketTimeout = GraphqlClientConfiguration.DEFAULT_SOCKET_TIMEOUT;
+    private int requestPoolTimeout = GraphqlClientConfiguration.DEFAULT_REQUESTPOOL_TIMEOUT;
+    private String[] httpHeaders = new String[0];
+    private String[] cacheConfigurations = new String[0];
+
+    GraphqlClientConfigurationImpl(String url) {
+        this.url = url;
+    }
+
+    GraphqlClientConfigurationImpl(GraphqlClientConfiguration configuration) {
+        identifier = configuration.identifier();
+        url = configuration.url();
+        httpMethod = configuration.httpMethod();
+        acceptSelfSignedCertificates = configuration.acceptSelfSignedCertificates();
+        allowHttpProtocol = configuration.allowHttpProtocol();
+        maxHttpConnections = configuration.maxHttpConnections();
+        connectionTimeout = configuration.connectionTimeout();
+        socketTimeout = configuration.socketTimeout();
+        requestPoolTimeout = configuration.requestPoolTimeout();
+        httpHeaders = configuration.httpHeaders();
+        cacheConfigurations = configuration.cacheConfigurations();
+    }
+
+    @Override
+    public Class<? extends Annotation> annotationType() {
+        return GraphqlClientConfiguration.class;
+    }
+
+    @Override
+    public String identifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    @Override
+    public String url() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public HttpMethod httpMethod() {
+        return httpMethod;
+    }
+
+    public void setHttpMethod(HttpMethod httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    @Override
+    public boolean acceptSelfSignedCertificates() {
+        return acceptSelfSignedCertificates;
+    }
+
+    public void setAcceptSelfSignedCertificates(boolean acceptSelfSignedCertificates) {
+        this.acceptSelfSignedCertificates = acceptSelfSignedCertificates;
+    }
+
+    @Override
+    public boolean allowHttpProtocol() {
+        return allowHttpProtocol;
+    }
+
+    public void setAllowHttpProtocol(boolean allowHttpProtocol) {
+        this.allowHttpProtocol = allowHttpProtocol;
+    }
+
+    @Override
+    public int maxHttpConnections() {
+        return maxHttpConnections;
+    }
+
+    public void setMaxHttpConnections(int maxHttpConnections) {
+        this.maxHttpConnections = maxHttpConnections;
+    }
+
+    @Override
+    public int connectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    @Override
+    public int socketTimeout() {
+        return socketTimeout;
+    }
+
+    public void setSocketTimeout(int socketTimeout) {
+        this.socketTimeout = socketTimeout;
+    }
+
+    @Override
+    public int requestPoolTimeout() {
+        return requestPoolTimeout;
+    }
+
+    public void setRequestPoolTimeout(int requestPoolTimeout) {
+        this.requestPoolTimeout = requestPoolTimeout;
+    }
+
+    @Override
+    public String[] httpHeaders() {
+        return httpHeaders;
+    }
+
+    public void setHttpHeaders(String... httpHeaders) {
+        this.httpHeaders = httpHeaders;
+    }
+
+    @Override
+    public String[] cacheConfigurations() {
+        return cacheConfigurations;
+    }
+
+    public void setCacheConfigurations(String... cacheConfigurations) {
+        this.cacheConfigurations = cacheConfigurations;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -110,6 +110,7 @@ public class GraphqlClientImpl implements GraphqlClient {
             LOGGER.warn("Request pool timeout is too big: {}. This may cause Thread starvation and should be urgently reviewed.",
                 configuration.requestPoolTimeout());
         }
+
         this.configuration = configuration;
         gson = new Gson();
         metrics = metricsRegistry != null

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -95,6 +95,21 @@ public class GraphqlClientImpl implements GraphqlClient {
 
     @Activate
     public void activate(GraphqlClientConfiguration configuration) throws Exception {
+        if (configuration.socketTimeout() <= 0 || configuration.connectionTimeout() <= 0 || configuration.requestPoolTimeout() <= 0) {
+            throw new IllegalArgumentException("infinite timeout forbidden");
+        }
+        if (configuration.socketTimeout() > GraphqlClientConfiguration.DEFAULT_SOCKET_TIMEOUT) {
+            LOGGER.warn("Socket timeout is too big: {}. This may cause Thread starvation and should be urgently reviewed.",
+                configuration.socketTimeout());
+        }
+        if (configuration.connectionTimeout() > GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT) {
+            LOGGER.warn("Connection timeout is too big: {}. This may cause Thread starvation and should be urgently reviewed.",
+                configuration.connectionTimeout());
+        }
+        if (configuration.requestPoolTimeout() > GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT) {
+            LOGGER.warn("Request pool timeout is too big: {}. This may cause Thread starvation and should be urgently reviewed.",
+                configuration.requestPoolTimeout());
+        }
         this.configuration = configuration;
         gson = new Gson();
         metrics = metricsRegistry != null

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -91,31 +91,45 @@ public class GraphqlClientImpl implements GraphqlClient {
     private Gson gson;
     private Map<String, Cache<CacheKey, GraphqlResponse<?, ?>>> caches;
     private GraphqlClientMetrics metrics;
-    private GraphqlClientConfiguration configuration;
+    private GraphqlClientConfigurationImpl configuration;
 
     @Activate
     public void activate(GraphqlClientConfiguration configuration) throws Exception {
-        if (configuration.socketTimeout() <= 0 || configuration.connectionTimeout() <= 0 || configuration.requestPoolTimeout() <= 0) {
-            throw new IllegalArgumentException("infinite timeout forbidden");
+        this.configuration = new GraphqlClientConfigurationImpl(configuration);
+        this.gson = new Gson();
+        this.metrics = metricsRegistry != null
+            ? new GraphqlClientMetricsImpl(metricsRegistry, configuration)
+            : GraphqlClientMetrics.NOOP;
+
+        if (this.configuration.socketTimeout() <= 0) {
+            LOGGER.warn("Socket timeout set to infinity. This may cause Thread starvation and should be urgently reviewed. Falling back to "
+                + "default configuration.");
+            this.configuration.setSocketTimeout(GraphqlClientConfiguration.DEFAULT_SOCKET_TIMEOUT);
         }
-        if (configuration.socketTimeout() > GraphqlClientConfiguration.DEFAULT_SOCKET_TIMEOUT) {
+        if (this.configuration.socketTimeout() > GraphqlClientConfiguration.DEFAULT_SOCKET_TIMEOUT) {
             LOGGER.warn("Socket timeout is too big: {}. This may cause Thread starvation and should be urgently reviewed.",
                 configuration.socketTimeout());
         }
-        if (configuration.connectionTimeout() > GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT) {
+        if (this.configuration.connectionTimeout() <= 0) {
+            LOGGER.warn(
+                "Connection timeout set to infinity. This may cause Thread starvation and should be urgently reviewed. Falling back to "
+                    + "default configuration.");
+            this.configuration.setConnectionTimeout(GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT);
+        }
+        if (this.configuration.connectionTimeout() > GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT) {
             LOGGER.warn("Connection timeout is too big: {}. This may cause Thread starvation and should be urgently reviewed.",
                 configuration.connectionTimeout());
         }
-        if (configuration.requestPoolTimeout() > GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT) {
+        if (this.configuration.requestPoolTimeout() <= 0) {
+            LOGGER.warn(
+                "Connection timeout set to infinity. This may cause Thread starvation and should be urgently reviewed. Falling back to "
+                    + "default configuration.");
+            this.configuration.setRequestPoolTimeout(GraphqlClientConfiguration.DEFAULT_REQUESTPOOL_TIMEOUT);
+        }
+        if (this.configuration.requestPoolTimeout() > GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT) {
             LOGGER.warn("Request pool timeout is too big: {}. This may cause Thread starvation and should be urgently reviewed.",
                 configuration.requestPoolTimeout());
         }
-
-        this.configuration = configuration;
-        gson = new Gson();
-        metrics = metricsRegistry != null
-            ? new GraphqlClientMetricsImpl(metricsRegistry, configuration)
-            : GraphqlClientMetrics.NOOP;
 
         configureCaches(configuration);
         configureHttpClient();

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
@@ -12,5 +12,5 @@
  *
  ******************************************************************************/
 
-@org.osgi.annotation.versioning.Version("1.7.0")
+@org.osgi.annotation.versioning.Version("1.7.1")
 package com.adobe.cq.commerce.graphql.client;

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -79,6 +79,24 @@ public class GraphqlClientImplTest {
         graphqlClient.client = Mockito.mock(HttpClient.class);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidSocketTimeout() throws Exception {
+        mockConfig.setSocketTimeout(0);
+        graphqlClient.activate(mockConfig);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidConnectionTimeout() throws Exception {
+        mockConfig.setConnectionTimeout(0);
+        graphqlClient.activate(mockConfig);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRequestPoolTimeout() throws Exception {
+        mockConfig.setRequestPoolTimeout(0);
+        graphqlClient.activate(mockConfig);
+    }
+
     @Test
     public void testRequestResponse() throws Exception {
         TestUtils.setupHttpResponse("sample-graphql-response.json", graphqlClient.client, HttpStatus.SC_OK);

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -25,10 +25,17 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.message.BasicHeader;
+import org.hamcrest.CustomMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
 import com.adobe.cq.commerce.graphql.client.GraphqlClientConfiguration;
 import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
@@ -46,6 +53,10 @@ import com.google.gson.JsonParseException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class GraphqlClientImplTest {
 
@@ -72,7 +83,7 @@ public class GraphqlClientImplTest {
         mockConfig = new MockGraphqlClientConfiguration();
         // Add three test headers, one with extra white space around " : " to make sure we properly trim spaces, and one empty header
         mockConfig.setHttpHeaders(HttpHeaders.AUTHORIZATION + ":" + AUTH_HEADER_VALUE, HttpHeaders.CACHE_CONTROL + " : "
-            + CACHE_HEADER_VALUE,
+                + CACHE_HEADER_VALUE,
             "");
 
         graphqlClient.activate(mockConfig);
@@ -95,6 +106,28 @@ public class GraphqlClientImplTest {
     public void testInvalidRequestPoolTimeout() throws Exception {
         mockConfig.setRequestPoolTimeout(0);
         graphqlClient.activate(mockConfig);
+    }
+
+    @Test
+    public void testWarningsAreLoggedForTimeoutsTooBig() throws Exception {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        Logger logger = loggerContext.getLogger(GraphqlClientImpl.class);
+        logger.setLevel(Level.WARN);
+        Appender<ILoggingEvent> appender = mock(Appender.class);
+        logger.addAppender(appender);
+
+        mockConfig.setSocketTimeout(10000);
+        mockConfig.setConnectionTimeout(10000);
+        mockConfig.setRequestPoolTimeout(10000);
+        graphqlClient.activate(mockConfig);
+
+        // verify the 3 warnings are logged
+        verify(appender, times(3)).doAppend(argThat(new CustomMatcher<ILoggingEvent>("log event of level warn") {
+            @Override
+            public boolean matches(Object o) {
+                return o instanceof ILoggingEvent && ((ILoggingEvent) o).getLevel() == Level.WARN;
+            }
+        }));
     }
 
     @Test

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -81,6 +81,7 @@ public class GraphqlClientImplTest {
         graphqlClient = new GraphqlClientImpl();
 
         mockConfig = new MockGraphqlClientConfiguration();
+        mockConfig.setIdentifier("mockIdentifier");
         // Add three test headers, one with extra white space around " : " to make sure we properly trim spaces, and one empty header
         mockConfig.setHttpHeaders(HttpHeaders.AUTHORIZATION + ":" + AUTH_HEADER_VALUE, HttpHeaders.CACHE_CONTROL + " : "
             + CACHE_HEADER_VALUE,
@@ -90,22 +91,16 @@ public class GraphqlClientImplTest {
         graphqlClient.client = Mockito.mock(HttpClient.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidSocketTimeout() throws Exception {
+    @Test
+    public void testInvalidTimeouts() throws Exception {
         mockConfig.setSocketTimeout(0);
-        graphqlClient.activate(mockConfig);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidConnectionTimeout() throws Exception {
         mockConfig.setConnectionTimeout(0);
-        graphqlClient.activate(mockConfig);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidRequestPoolTimeout() throws Exception {
         mockConfig.setRequestPoolTimeout(0);
         graphqlClient.activate(mockConfig);
+
+        assertEquals(GraphqlClientConfiguration.DEFAULT_SOCKET_TIMEOUT, graphqlClient.getConfiguration().socketTimeout());
+        assertEquals(GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT, graphqlClient.getConfiguration().connectionTimeout());
+        assertEquals(GraphqlClientConfiguration.DEFAULT_REQUESTPOOL_TIMEOUT, graphqlClient.getConfiguration().requestPoolTimeout());
     }
 
     @Test
@@ -151,8 +146,6 @@ public class GraphqlClientImplTest {
         assertEquals(1, response.getErrors().size());
         Error error = response.getErrors().get(0);
         assertEquals("Error message", error.message);
-
-        assertEquals(GraphqlClientConfiguration.DEFAULT_IDENTIFIER, graphqlClient.getIdentifier());
     }
 
     @Test
@@ -300,6 +293,7 @@ public class GraphqlClientImplTest {
     @Test
     public void testGetConfiguration() {
         GraphqlClientConfiguration configuration = graphqlClient.getConfiguration();
-        assertEquals(mockConfig, configuration);
+        assertEquals(mockConfig.identifier(), configuration.identifier());
+        assertEquals("mockIdentifier", graphqlClient.getIdentifier());
     }
 }

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -83,7 +83,7 @@ public class GraphqlClientImplTest {
         mockConfig = new MockGraphqlClientConfiguration();
         // Add three test headers, one with extra white space around " : " to make sure we properly trim spaces, and one empty header
         mockConfig.setHttpHeaders(HttpHeaders.AUTHORIZATION + ":" + AUTH_HEADER_VALUE, HttpHeaders.CACHE_CONTROL + " : "
-                + CACHE_HEADER_VALUE,
+            + CACHE_HEADER_VALUE,
             "");
 
         graphqlClient.activate(mockConfig);

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
@@ -11,117 +11,14 @@
  *    governing permissions and limitations under the License.
  *
  ******************************************************************************/
-
 package com.adobe.cq.commerce.graphql.client.impl;
 
-import java.lang.annotation.Annotation;
-
-import com.adobe.cq.commerce.graphql.client.GraphqlClientConfiguration;
-import com.adobe.cq.commerce.graphql.client.HttpMethod;
-
-public class MockGraphqlClientConfiguration implements Annotation, GraphqlClientConfiguration {
+class MockGraphqlClientConfiguration extends GraphqlClientConfigurationImpl {
 
     public static final String URL = "https://hostname/graphql";
-    private String url;
-    private Boolean acceptSelfSignedCertificates;
-    private Boolean allowHttpProtocol;
-    private String[] httpHeaders;
-    private String[] cacheConfigurations;
-    private int socketTimeout = GraphqlClientConfiguration.DEFAULT_SOCKET_TIMEOUT;
-    private int connectionTimeout = GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT;
-    private int requestPoolTimeout = GraphqlClientConfiguration.DEFAULT_REQUESTPOOL_TIMEOUT;
 
-    @Override
-    public String identifier() {
-        return GraphqlClientConfiguration.DEFAULT_IDENTIFIER;
+    public MockGraphqlClientConfiguration() {
+        super(URL);
     }
 
-    @Override
-    public String url() {
-        return url != null ? url : URL;
-    }
-
-    @Override
-    public HttpMethod httpMethod() {
-        return HttpMethod.POST;
-    }
-
-    @Override
-    public boolean acceptSelfSignedCertificates() {
-        return acceptSelfSignedCertificates != null ? acceptSelfSignedCertificates
-            : GraphqlClientConfiguration.ACCEPT_SELF_SIGNED_CERTIFICATES;
-    }
-
-    @Override
-    public boolean allowHttpProtocol() {
-        return allowHttpProtocol != null ? allowHttpProtocol
-            : GraphqlClientConfiguration.ALLOW_HTTP_PROTOCOL;
-    }
-
-    @Override
-    public int maxHttpConnections() {
-        return GraphqlClientConfiguration.MAX_HTTP_CONNECTIONS_DEFAULT;
-    }
-
-    @Override
-    public int connectionTimeout() {
-        return connectionTimeout;
-    }
-
-    @Override
-    public int socketTimeout() {
-        return socketTimeout;
-    }
-
-    @Override
-    public int requestPoolTimeout() {
-        return requestPoolTimeout;
-    }
-
-    @Override
-    public Class<? extends Annotation> annotationType() {
-        return GraphqlClientConfiguration.class;
-    }
-
-    @Override
-    public String[] httpHeaders() {
-        return httpHeaders;
-    }
-
-    @Override
-    public String[] cacheConfigurations() {
-        return cacheConfigurations;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    public void setAcceptSelfSignedCertificates(Boolean acceptSelfSignedCertificates) {
-        this.acceptSelfSignedCertificates = acceptSelfSignedCertificates;
-    }
-
-    public void setAllowHttpProtocol(Boolean allowHttpProtocol) {
-        this.allowHttpProtocol = allowHttpProtocol;
-    }
-
-    public void setHttpHeaders(String... httpHeaders) {
-        this.httpHeaders = httpHeaders;
-    }
-
-    public void setCacheConfigurations(String... cacheConfigurations) {
-        this.cacheConfigurations = cacheConfigurations;
-    }
-
-    public void setSocketTimeout(int socketTimeout) {
-        this.socketTimeout = socketTimeout;
-    }
-
-    public void setConnectionTimeout(int connectionTimeout) {
-        this.connectionTimeout = connectionTimeout;
-    }
-
-    public void setRequestPoolTimeout(int requestPoolTimeout) {
-        this.requestPoolTimeout = requestPoolTimeout;
-    }
 }

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockGraphqlClientConfiguration.java
@@ -27,6 +27,9 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
     private Boolean allowHttpProtocol;
     private String[] httpHeaders;
     private String[] cacheConfigurations;
+    private int socketTimeout = GraphqlClientConfiguration.DEFAULT_SOCKET_TIMEOUT;
+    private int connectionTimeout = GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT;
+    private int requestPoolTimeout = GraphqlClientConfiguration.DEFAULT_REQUESTPOOL_TIMEOUT;
 
     @Override
     public String identifier() {
@@ -62,17 +65,17 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
 
     @Override
     public int connectionTimeout() {
-        return GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT;
+        return connectionTimeout;
     }
 
     @Override
     public int socketTimeout() {
-        return GraphqlClientConfiguration.DEFAULT_SOCKET_TIMEOUT;
+        return socketTimeout;
     }
 
     @Override
     public int requestPoolTimeout() {
-        return GraphqlClientConfiguration.DEFAULT_REQUESTPOOL_TIMEOUT;
+        return requestPoolTimeout;
     }
 
     @Override
@@ -94,7 +97,7 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
         this.url = url;
     }
 
-    public void setAcceptSelfSignedCertificates(boolean acceptSelfSignedCertificates) {
+    public void setAcceptSelfSignedCertificates(Boolean acceptSelfSignedCertificates) {
         this.acceptSelfSignedCertificates = acceptSelfSignedCertificates;
     }
 
@@ -108,5 +111,17 @@ public class MockGraphqlClientConfiguration implements Annotation, GraphqlClient
 
     public void setCacheConfigurations(String... cacheConfigurations) {
         this.cacheConfigurations = cacheConfigurations;
+    }
+
+    public void setSocketTimeout(int socketTimeout) {
+        this.socketTimeout = socketTimeout;
+    }
+
+    public void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public void setRequestPoolTimeout(int requestPoolTimeout) {
+        this.requestPoolTimeout = requestPoolTimeout;
     }
 }

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockServerHelper.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockServerHelper.java
@@ -23,7 +23,6 @@ import org.apache.http.HttpHeaders;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.configuration.ConfigurationProperties;
 import org.mockserver.integration.ClientAndServer;
-import org.mockserver.mockserver.MockServer;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.slf4j.Logger;

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockServerHelper.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/MockServerHelper.java
@@ -21,7 +21,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHeaders;
 import org.mockserver.client.MockServerClient;
+import org.mockserver.configuration.ConfigurationProperties;
 import org.mockserver.integration.ClientAndServer;
+import org.mockserver.mockserver.MockServer;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.slf4j.Logger;
@@ -36,6 +38,10 @@ import static org.junit.Assert.assertEquals;
 public class MockServerHelper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MockServerHelper.class);
+
+    static {
+        ConfigurationProperties.logLevel("ERROR");
+    }
 
     private final ClientAndServer mockServer;
     private final GraphqlRequest dummy = new GraphqlRequest("{dummy}");

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,6 +1,0 @@
-# See https://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html for the syntax of this file
-
-# Disable logger during tests
-org.slf4j.simpleLogger.log.org.mockserver.mock.HttpStateHandler=off
-org.slf4j.simpleLogger.log.com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl=off
-org.slf4j.simpleLogger.log.com.adobe.cq.commerce.graphql.client.impl.GraphqlClientAdapterFactory=off


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces runtime checks on the configured timeout. If they are 0 or smaller now an IAE will be thrown. If they are bigger than the defaults a warning will be logged. 

While this is a breaking change I think it does not necessarily need to be released with a major version.

## Related Issue

CIF-2117

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
