### PR TITLE
CIF-2278: prefix metric labels

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetricsImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetricsImpl.java
@@ -27,10 +27,10 @@ import com.codahale.metrics.Timer;
 
 class GraphqlClientMetricsImpl implements GraphqlClientMetrics, Closeable {
 
-    private static final String METRIC_LABEL_IDENTIFIER = "identifier";
-    private static final String METRIC_LABEL_ENDPOINT = "endpoint";
-    private static final String METRIC_LABEL_STATUS_CODE = "status";
-    private static final String METRIC_LABEL_CACHE_NAME = "cacheName";
+    private static final String METRIC_LABEL_IDENTIFIER = "gql_client_identifier";
+    private static final String METRIC_LABEL_ENDPOINT = "gql_client_endpoint";
+    private static final String METRIC_LABEL_STATUS_CODE = "gql_response_status";
+    private static final String METRIC_LABEL_CACHE_NAME = "gql_cache_name";
 
     private final MetricRegistry metrics;
     private final GraphqlClientConfiguration configuration;

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
@@ -71,7 +71,7 @@ public class GraphqlClientImplMetricsTest {
         graphqlClient.execute(dummy, Data.class, Error.class);
 
         // then
-        Timer timer = metricRegistry.getTimers().get("graphql-client.request.duration;endpoint=http://foo.bar/api");
+        Timer timer = metricRegistry.getTimers().get("graphql-client.request.duration;gql_client_endpoint=http://foo.bar/api");
         assertNotNull(timer);
         assertEquals(1, timer.getCount());
     }
@@ -89,21 +89,23 @@ public class GraphqlClientImplMetricsTest {
             });
 
         // when, then
-        Gauge<?> fooHits = metricRegistry.getGauges().get("graphql-client.cache.hits;identifier=default;cacheName=foo");
+        Gauge<?> fooHits = metricRegistry.getGauges().get("graphql-client.cache.hits;gql_client_identifier=default;gql_cache_name=foo");
         assertNotNull(fooHits);
-        Gauge<?> fooMisses = metricRegistry.getGauges().get("graphql-client.cache.misses;identifier=default;cacheName=foo");
+        Gauge<?> fooMisses = metricRegistry.getGauges().get("graphql-client.cache.misses;gql_client_identifier=default;gql_cache_name=foo");
         assertNotNull(fooMisses);
-        Gauge<?> fooEvictions = metricRegistry.getGauges().get("graphql-client.cache.evictions;identifier=default;cacheName=foo");
+        Gauge<?> fooEvictions = metricRegistry.getGauges().get(
+            "graphql-client.cache.evictions;gql_client_identifier=default;gql_cache_name=foo");
         assertNotNull(fooEvictions);
-        Gauge<?> fooUsage = metricRegistry.getGauges().get("graphql-client.cache.usage;identifier=default;cacheName=foo");
+        Gauge<?> fooUsage = metricRegistry.getGauges().get("graphql-client.cache.usage;gql_client_identifier=default;gql_cache_name=foo");
         assertNotNull(fooUsage);
-        Gauge<?> barHits = metricRegistry.getGauges().get("graphql-client.cache.hits;identifier=default;cacheName=bar");
+        Gauge<?> barHits = metricRegistry.getGauges().get("graphql-client.cache.hits;gql_client_identifier=default;gql_cache_name=bar");
         assertNotNull(barHits);
-        Gauge<?> barMisses = metricRegistry.getGauges().get("graphql-client.cache.misses;identifier=default;cacheName=bar");
+        Gauge<?> barMisses = metricRegistry.getGauges().get("graphql-client.cache.misses;gql_client_identifier=default;gql_cache_name=bar");
         assertNotNull(barMisses);
-        Gauge<?> barEvictions = metricRegistry.getGauges().get("graphql-client.cache.evictions;identifier=default;cacheName=bar");
+        Gauge<?> barEvictions = metricRegistry.getGauges().get(
+            "graphql-client.cache.evictions;gql_client_identifier=default;gql_cache_name=bar");
         assertNotNull(barEvictions);
-        Gauge<?> barUsage = metricRegistry.getGauges().get("graphql-client.cache.usage;identifier=default;cacheName=bar");
+        Gauge<?> barUsage = metricRegistry.getGauges().get("graphql-client.cache.usage;gql_client_identifier=default;gql_cache_name=bar");
         assertNotNull(barUsage);
 
         // and when, then
@@ -120,11 +122,12 @@ public class GraphqlClientImplMetricsTest {
 
         // when, then
         Gauge<?> availableConnections = metricRegistry.getGauges().get(
-            "graphql-client.connection-pool.available-connections;identifier=default");
+            "graphql-client.connection-pool.available-connections;gql_client_identifier=default");
         assertNotNull(availableConnections);
-        Gauge<?> pendingRequests = metricRegistry.getGauges().get("graphql-client.connection-pool.pending-requests;identifier=default");
+        Gauge<?> pendingRequests = metricRegistry.getGauges().get(
+            "graphql-client.connection-pool.pending-requests;gql_client_identifier=default");
         assertNotNull(pendingRequests);
-        Gauge<?> usage = metricRegistry.getGauges().get("graphql-client.connection-pool.usage;identifier=default");
+        Gauge<?> usage = metricRegistry.getGauges().get("graphql-client.connection-pool.usage;gql_client_identifier=default");
         assertNotNull(usage);
 
         // and when, then
@@ -146,10 +149,10 @@ public class GraphqlClientImplMetricsTest {
         }
 
         // then
-        Timer timer = metricRegistry.getTimers().get("graphql-client.request.duration;endpoint=http://foo.bar/api");
+        Timer timer = metricRegistry.getTimers().get("graphql-client.request.duration;gql_client_endpoint=http://foo.bar/api");
         assertNotNull(timer);
         assertEquals(0, timer.getCount());
-        Counter counter = metricRegistry.getCounters().get("graphql-client.request.errors;endpoint=http://foo.bar/api");
+        Counter counter = metricRegistry.getCounters().get("graphql-client.request.errors;gql_client_endpoint=http://foo.bar/api");
         assertNotNull(counter);
         assertEquals(1, counter.getCount());
     }
@@ -174,10 +177,10 @@ public class GraphqlClientImplMetricsTest {
         }
 
         // then
-        Timer timer = metricRegistry.getTimers().get("graphql-client.request.duration;endpoint=http://foo.bar/api");
+        Timer timer = metricRegistry.getTimers().get("graphql-client.request.duration;gql_client_endpoint=http://foo.bar/api");
         assertNotNull(timer);
         assertEquals(0, timer.getCount());
-        Counter counter = metricRegistry.getCounters().get("graphql-client.request.errors;endpoint=http://foo.bar/api");
+        Counter counter = metricRegistry.getCounters().get("graphql-client.request.errors;gql_client_endpoint=http://foo.bar/api");
         assertNotNull(counter);
         assertEquals(1, counter.getCount());
     }
@@ -196,7 +199,8 @@ public class GraphqlClientImplMetricsTest {
         }
 
         // then
-        Counter counter = metricRegistry.getCounters().get("graphql-client.request.errors;endpoint=http://foo.bar/api;status=500");
+        Counter counter = metricRegistry.getCounters().get(
+            "graphql-client.request.errors;gql_client_endpoint=http://foo.bar/api;gql_response_status=500");
         assertNotNull(counter);
         assertEquals(1, counter.getCount());
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In order to distinguish the graphqlclient metric label values from others in the contexts independent from the metric itself we must use reasonable names that are clearly different from other uses. 

For example on prometheus `label_values(instance)` 

## Related Issue

CIF-2278

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit tests, manual

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
