### PR TITLE
CIF-2710: register GraphqlClient(s) only with a valid url

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -15,6 +15,8 @@ package com.adobe.cq.commerce.graphql.client.impl;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -139,6 +141,17 @@ public class GraphqlClientImpl implements GraphqlClient {
         if (this.configuration.requestPoolTimeout() > GraphqlClientConfiguration.DEFAULT_CONNECTION_TIMEOUT) {
             LOGGER.warn("Request pool timeout is too big: {}. This may cause Thread starvation and should be urgently reviewed.",
                 configuration.requestPoolTimeout());
+        }
+
+        if (StringUtils.isBlank(this.configuration.url())) {
+            throw new ComponentException("No endpoint url");
+        } else {
+            try {
+                // validate url syntax
+                new URL(this.configuration.url());
+            } catch (MalformedURLException ex) {
+                throw new ComponentException("Invalid endpoint url", ex);
+            }
         }
 
         if (StringUtils.startsWith(this.configuration.url(), "http://")) {

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
@@ -118,7 +118,7 @@ public class GraphqlClientImplMetricsTest {
         // given
         TestUtils.setupHttpResponse("sample-graphql-response.json", graphqlClient.client, HttpStatus.SC_OK);
         MockOsgi.activate(graphqlClient, aemContext.bundleContext(),
-            "identifier", "default");
+            "identifier", "default", "url", "https://example.com");
 
         // when, then
         Gauge<?> availableConnections = metricRegistry.getGauges().get(

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -36,6 +36,7 @@ import org.hamcrest.CustomMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.osgi.service.component.ComponentException;
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
@@ -100,6 +101,18 @@ public class GraphqlClientImplTest {
 
         graphqlClient.activate(mockConfig);
         graphqlClient.client = Mockito.mock(HttpClient.class);
+    }
+
+    @Test(expected = ComponentException.class)
+    public void testEmptyUrlThrows() throws Exception {
+        mockConfig.setUrl("");
+        graphqlClient.activate(mockConfig);
+    }
+
+    @Test(expected = ComponentException.class)
+    public void testInvalidUrlThrows() throws Exception {
+        mockConfig.setUrl("$[env:URL]");
+        graphqlClient.activate(mockConfig);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently we only prevent endpoint urls with an insecure protocol if not explicitly allowed. Empty urls and invalid ones however still work and cause runtime failures later when using the GraphqlClient.

In order to have a reliable set of properly configured GraphqlClient services this PR validates the given url further by checking for non-empty and a valid url syntax.

## Related Issue

CIF-2710, CIF-2517, CIF-2001

## Motivation and Context

Improve support for multiple commerce backends

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
