### PR TITLE
CIF-2697: Implement cache invalidation handler

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/CacheInvalidationHandler.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/CacheInvalidationHandler.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *
+ *    Copyright 2022 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+package com.adobe.cq.commerce.graphql.client.impl;
+
+import java.util.List;
+
+import org.apache.sling.event.dea.DEAConstants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+import org.osgi.service.event.EventHandler;
+
+import com.day.cq.replication.ReplicationAction;
+
+/**
+ * This {@link EventHandler} handles replication actions to invalidate all the caches of the GraphqlClientImpls.
+ * <p>
+ * It is meant to run on publish and handle flush replication actions. With the supported API level, it is currently not possible to get
+ * the agent that sent the replication action event and so the handler invalidates all caches for each event.
+ */
+@Component(
+    configurationPolicy = ConfigurationPolicy.REQUIRE,
+    immediate = true,
+    property = {
+        EventConstants.EVENT_TOPIC + "=" + ReplicationAction.EVENT_TOPIC,
+        EventConstants.EVENT_FILTER + "=(!(" + DEAConstants.PROPERTY_APPLICATION + "=*))"
+    },
+    service = EventHandler.class)
+public class CacheInvalidationHandler implements EventHandler {
+
+    @Reference(
+        cardinality = ReferenceCardinality.AT_LEAST_ONE,
+        policy = ReferencePolicy.STATIC,
+        policyOption = ReferencePolicyOption.GREEDY)
+    protected List<GraphqlClientImpl> graphqlClients;
+
+    @Override
+    public void handleEvent(Event event) {
+        for (GraphqlClientImpl graphqlClient : graphqlClients) {
+            graphqlClient.invalidateCaches();
+        }
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -84,7 +84,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
-@Component(service = GraphqlClient.class)
+@Component(service = { GraphqlClient.class, GraphqlClientImpl.class })
 @Designate(ocd = GraphqlClientConfiguration.class, factory = true)
 public class GraphqlClientImpl implements GraphqlClient {
 
@@ -211,6 +211,14 @@ public class GraphqlClientImpl implements GraphqlClient {
             }
         } else {
             caches = null; // make sure it's always reset
+        }
+    }
+
+    public void invalidateCaches() {
+        if (caches != null) {
+            for (Cache<?, ?> cache : caches.values()) {
+                cache.invalidateAll();
+            }
         }
     }
 

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -51,6 +51,8 @@ import com.adobe.cq.commerce.graphql.client.RequestOptions;
 import com.adobe.cq.commerce.graphql.client.impl.TestUtils.GetQueryMatcher;
 import com.adobe.cq.commerce.graphql.client.impl.TestUtils.HeadersMatcher;
 import com.adobe.cq.commerce.graphql.client.impl.TestUtils.RequestBodyMatcher;
+import com.day.cq.replication.ReplicationAction;
+import com.day.cq.replication.ReplicationActionType;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializationContext;
@@ -356,6 +358,14 @@ public class GraphqlClientImplTest {
         // with keep alive header timeout larger than custom
         prepareResponse(httpResponse, "15");
         assertEquals(customKeepAlive * 1000L, connectionKeepAliveStrategy.getKeepAliveDuration(httpResponse, null));
+    }
+
+    @Test
+    public void testCacheInvalidationIgnored() {
+        // the subject is not configured for caching, if it is invalidated anyway it should not fail
+        CacheInvalidationHandler handler = new CacheInvalidationHandler();
+        handler.graphqlClients = Collections.singletonList(graphqlClient);
+        handler.handleEvent(new ReplicationAction(ReplicationActionType.ACTIVATE, "/").toEvent());
     }
 
     private void prepareResponse(HttpResponse httpResponse, String responseKeepAlive) {

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/TestUtils.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/TestUtils.java
@@ -32,11 +32,14 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.mockito.ArgumentMatcher;
-import org.mockito.Mockito;
 
 import com.adobe.cq.commerce.graphql.client.GraphqlRequest;
 import com.adobe.cq.commerce.graphql.client.HttpMethod;
 import com.google.gson.Gson;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestUtils {
 
@@ -150,47 +153,48 @@ public class TestUtils {
      */
     public static String setupHttpResponse(String filename, HttpClient httpClient, int httpCode) throws IOException {
         String json = getResource(filename);
-
-        HttpEntity mockedHttpEntity = Mockito.mock(HttpEntity.class);
-        HttpResponse mockedHttpResponse = Mockito.mock(HttpResponse.class);
-        StatusLine mockedStatusLine = Mockito.mock(StatusLine.class);
-
         byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
-        Mockito.when(mockedHttpEntity.getContent()).thenReturn(new ByteArrayInputStream(bytes));
-        Mockito.when(mockedHttpEntity.getContentLength()).thenReturn(new Long(bytes.length));
 
-        Mockito.when(mockedHttpResponse.getEntity()).thenReturn(mockedHttpEntity);
-        Mockito.when(httpClient.execute((HttpUriRequest) Mockito.any())).thenReturn(mockedHttpResponse);
+        HttpResponse mockedHttpResponse = mock(HttpResponse.class);
+        StatusLine mockedStatusLine = mock(StatusLine.class);
 
-        Mockito.when(mockedStatusLine.getStatusCode()).thenReturn(httpCode);
-        Mockito.when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);
+        when(mockedHttpResponse.getEntity()).then(inv -> {
+            HttpEntity mockHttpEntity = mock(HttpEntity.class);
+            when(mockHttpEntity.getContent()).thenReturn(new ByteArrayInputStream(bytes));
+            when(mockHttpEntity.getContentLength()).thenReturn(new Long(bytes.length));
+            return mockHttpEntity;
+        });
+        when(httpClient.execute((HttpUriRequest) any())).thenReturn(mockedHttpResponse);
+
+        when(mockedStatusLine.getStatusCode()).thenReturn(httpCode);
+        when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);
 
         return json;
     }
 
     public static void setupHttpResponse(InputStream data, HttpClient httpClient, int httpCode) throws IOException {
-        HttpEntity mockedHttpEntity = Mockito.mock(HttpEntity.class);
-        HttpResponse mockedHttpResponse = Mockito.mock(HttpResponse.class);
-        StatusLine mockedStatusLine = Mockito.mock(StatusLine.class);
+        HttpEntity mockedHttpEntity = mock(HttpEntity.class);
+        HttpResponse mockedHttpResponse = mock(HttpResponse.class);
+        StatusLine mockedStatusLine = mock(StatusLine.class);
 
-        Mockito.when(mockedHttpEntity.getContent()).thenReturn(data);
+        when(mockedHttpEntity.getContent()).thenReturn(data);
 
-        Mockito.when(mockedHttpResponse.getEntity()).thenReturn(mockedHttpEntity);
-        Mockito.when(httpClient.execute((HttpUriRequest) Mockito.any())).thenReturn(mockedHttpResponse);
+        when(mockedHttpResponse.getEntity()).thenReturn(mockedHttpEntity);
+        when(httpClient.execute((HttpUriRequest) any())).thenReturn(mockedHttpResponse);
 
-        Mockito.when(mockedStatusLine.getStatusCode()).thenReturn(httpCode);
-        Mockito.when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);
+        when(mockedStatusLine.getStatusCode()).thenReturn(httpCode);
+        when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);
     }
 
     public static void setupNullResponse(HttpClient httpClient) throws IOException {
-        HttpResponse mockedHttpResponse = Mockito.mock(HttpResponse.class);
-        StatusLine mockedStatusLine = Mockito.mock(StatusLine.class);
+        HttpResponse mockedHttpResponse = mock(HttpResponse.class);
+        StatusLine mockedStatusLine = mock(StatusLine.class);
 
-        Mockito.when(mockedHttpResponse.getEntity()).thenReturn(null);
-        Mockito.when(httpClient.execute((HttpUriRequest) Mockito.any())).thenReturn(mockedHttpResponse);
+        when(mockedHttpResponse.getEntity()).thenReturn(null);
+        when(httpClient.execute((HttpUriRequest) any())).thenReturn(mockedHttpResponse);
 
-        Mockito.when(mockedStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
-        Mockito.when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);
+        when(mockedStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+        when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);
     }
 
     public static String getResource(String filename) throws IOException {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently the entries of the internal cache(s) of the `GraphqlClientImpl` are only evicted by size and ttl constraints. They are not synchronised with other cache(s) (in particular dispatcher).

Consider the following scenario of a cache with ttl=10m
1. T=0: response cached for 10m
2. T=4: backend data changes, cached response becomes invalid
3. T=5: dispatcher flush, response still cached for another 5min
4. T=6: page is served and newly cached in dispatcher, response served with invalid data
5. T=10: cached response evicted

In this PR a naive `CacheInvalidationHandler` got introduced that listens for any `ReplicationAction` and flushes all internal caches along the line. This handler is supposed to be enabled on publishers and when caching is configured. 

## Related Issue

CIF-2697

## Motivation and Context


## How Has This Been Tested?

Unit tests, locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
