### PR TITLE
CIF-2785: register service manually to prevent extensive error logging

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -113,9 +113,6 @@ public class GraphqlClientImpl implements GraphqlClient {
         throws Exception {
         this.configuration = new GraphqlClientConfigurationImpl(configuration);
         this.gson = new Gson();
-        this.metrics = metricsRegistry != null
-            ? new GraphqlClientMetricsImpl(metricsRegistry, configuration)
-            : GraphqlClientMetrics.NOOP;
 
         if (this.configuration.socketTimeout() <= 0) {
             LOGGER.warn("Socket timeout set to infinity. This may cause Thread starvation and should be urgently reviewed. Falling back to "
@@ -182,6 +179,10 @@ public class GraphqlClientImpl implements GraphqlClient {
                 this.configuration.setHttpHeaders(newHeaders);
             }
         }
+
+        this.metrics = metricsRegistry != null
+            ? new GraphqlClientMetricsImpl(metricsRegistry, configuration)
+            : GraphqlClientMetrics.NOOP;
 
         configureCaches(configuration);
         client = configureHttpClientBuilder().build();

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -197,7 +197,9 @@ public class GraphqlClientImpl implements GraphqlClient {
         if (metrics instanceof GraphqlClientMetricsImpl) {
             ((GraphqlClientMetricsImpl) metrics).close();
         }
-        registration.unregister();
+        if (registration != null) {
+            registration.unregister();
+        }
     }
 
     private void configureCaches(GraphqlClientConfiguration configuration) {

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ConcurrencyTest.java
@@ -29,6 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
+import org.osgi.framework.BundleContext;
 
 import com.adobe.cq.commerce.graphql.client.GraphqlClientConfiguration;
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
@@ -36,6 +37,7 @@ import com.adobe.cq.commerce.graphql.client.impl.MockServerHelper.Data;
 import com.adobe.cq.commerce.graphql.client.impl.MockServerHelper.Error;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockserver.model.HttpStatusCode.INTERNAL_SERVER_ERROR_500;
 
 public class ConcurrencyTest {
@@ -63,7 +65,7 @@ public class ConcurrencyTest {
         config.setAcceptSelfSignedCertificates(true);
 
         graphqlClient = new GraphqlClientImpl();
-        graphqlClient.activate(config);
+        graphqlClient.activate(config, mock(BundleContext.class));
     }
 
     @Test(timeout = 15000)

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
@@ -18,6 +18,7 @@ import org.apache.sling.api.resource.Resource;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.osgi.framework.BundleContext;
 
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
 import com.google.common.collect.ImmutableMap;
@@ -83,7 +84,7 @@ public class GraphqlClientAdapterFactoryTest {
     @Test
     public void testErrorCases() throws Exception {
         GraphqlClientImpl graphqlClient = new GraphqlClientImpl();
-        graphqlClient.activate(new MockGraphqlClientConfiguration());
+        graphqlClient.activate(new MockGraphqlClientConfiguration(), mock(BundleContext.class));
 
         GraphqlClientAdapterFactory factory = new GraphqlClientAdapterFactory();
         factory.bindGraphqlClient(graphqlClient, null);

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplCachingTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplCachingTest.java
@@ -23,6 +23,7 @@ import org.apache.http.message.BasicHeader;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.osgi.framework.BundleContext;
 
 import com.adobe.cq.commerce.graphql.client.CachingStrategy;
 import com.adobe.cq.commerce.graphql.client.CachingStrategy.DataFetchingPolicy;
@@ -31,6 +32,7 @@ import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.graphql.client.RequestOptions;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class GraphqlClientImplCachingTest {
 
@@ -56,29 +58,29 @@ public class GraphqlClientImplCachingTest {
         MockGraphqlClientConfiguration config = new MockGraphqlClientConfiguration();
         config.setCacheConfigurations(MY_CACHE + ":true:100:5", MY_DISABLED_CACHE + ":false:100:5", "");
 
-        graphqlClient.activate(config);
-        graphqlClient.client = Mockito.mock(HttpClient.class);
+        graphqlClient.activate(config, mock(BundleContext.class));
+        graphqlClient.client = mock(HttpClient.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void testInvalidCacheConfiguration() throws Exception {
         MockGraphqlClientConfiguration config = new MockGraphqlClientConfiguration();
         config.setCacheConfigurations(MY_CACHE + ":true:"); // Not enough parameters
-        graphqlClient.activate(config);
+        graphqlClient.activate(config, mock(BundleContext.class));
     }
 
     @Test(expected = NumberFormatException.class)
     public void testInvalidMaxSizeParameter() throws Exception {
         MockGraphqlClientConfiguration config = new MockGraphqlClientConfiguration();
         config.setCacheConfigurations(MY_CACHE + ":true:bad:5"); // Cache max size must be an Integer
-        graphqlClient.activate(config);
+        graphqlClient.activate(config, mock(BundleContext.class));
     }
 
     @Test(expected = NumberFormatException.class)
     public void testInvalidTimeoutParameter() throws Exception {
         MockGraphqlClientConfiguration config = new MockGraphqlClientConfiguration();
         config.setCacheConfigurations(MY_CACHE + ":true:100:bad"); // Cache timeout must be an Integer
-        graphqlClient.activate(config);
+        graphqlClient.activate(config, mock(BundleContext.class));
     }
 
     @Test
@@ -213,8 +215,8 @@ public class GraphqlClientImplCachingTest {
     @Test
     public void testNoCache() throws Exception {
         graphqlClient = new GraphqlClientImpl();
-        graphqlClient.activate(new MockGraphqlClientConfiguration());
-        graphqlClient.client = Mockito.mock(HttpClient.class);
+        graphqlClient.activate(new MockGraphqlClientConfiguration(), mock(BundleContext.class));
+        graphqlClient.client = mock(HttpClient.class);
 
         CachingStrategy cachingStrategy = new CachingStrategy()
             .withCacheName(MY_CACHE)
@@ -230,8 +232,8 @@ public class GraphqlClientImplCachingTest {
         graphqlClient = new GraphqlClientImpl();
         MockGraphqlClientConfiguration config = new MockGraphqlClientConfiguration();
         config.setCacheConfigurations(ArrayUtils.EMPTY_STRING_ARRAY);
-        graphqlClient.activate(config);
-        graphqlClient.client = Mockito.mock(HttpClient.class);
+        graphqlClient.activate(config, mock(BundleContext.class));
+        graphqlClient.client = mock(HttpClient.class);
 
         CachingStrategy cachingStrategy = new CachingStrategy()
             .withCacheName(MY_CACHE)

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ProtocolTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/ProtocolTest.java
@@ -19,10 +19,16 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.HttpRequest;
+import org.osgi.framework.BundleContext;
 
 import com.adobe.cq.commerce.graphql.client.GraphqlResponse;
 import com.adobe.cq.commerce.graphql.client.impl.MockServerHelper.Data;
 import com.adobe.cq.commerce.graphql.client.impl.MockServerHelper.Error;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 public class ProtocolTest {
 
@@ -47,7 +53,7 @@ public class ProtocolTest {
         config.setAcceptSelfSignedCertificates(true);
 
         GraphqlClientImpl graphqlClient = new GraphqlClientImpl();
-        graphqlClient.activate(config);
+        graphqlClient.activate(config, mock(BundleContext.class));
 
         GraphqlResponse<Data, Error> response = mockServer.executeGraphqlClientDummyRequest(graphqlClient);
         mockServer.validateSampleResponse(response);
@@ -56,13 +62,15 @@ public class ProtocolTest {
     /**
      * Ensure HTTP communication is by default not allowed.
      */
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testSimpleRequest_HTTP_Disallowed() throws Exception {
         MockGraphqlClientConfiguration config = new MockGraphqlClientConfiguration();
         config.setUrl("http://localhost:" + mockServer.getLocalPort() + "/graphql");
 
+        BundleContext bundleContext = mock(BundleContext.class);
         GraphqlClientImpl graphqlClient = new GraphqlClientImpl();
-        graphqlClient.activate(config);
+        graphqlClient.activate(config, bundleContext);
+        verify(bundleContext, never()).registerService(any(Class.class), any(GraphqlClientImpl.class), any());
     }
 
     /**
@@ -75,7 +83,7 @@ public class ProtocolTest {
         config.setAllowHttpProtocol(true);
 
         GraphqlClientImpl graphqlClient = new GraphqlClientImpl();
-        graphqlClient.activate(config);
+        graphqlClient.activate(config, mock(BundleContext.class));
 
         GraphqlResponse<Data, Error> response = mockServer.executeGraphqlClientDummyRequest(graphqlClient);
         mockServer.validateSampleResponse(response);
@@ -88,7 +96,7 @@ public class ProtocolTest {
         config.setAcceptSelfSignedCertificates(true);
 
         GraphqlClientImpl graphqlClient = new GraphqlClientImpl();
-        graphqlClient.activate(config);
+        graphqlClient.activate(config, mock(BundleContext.class));
 
         MockServerClient client = mockServer.resetWithSampleResponse();
         mockServer.executeGraphqlClientDummyRequest(graphqlClient);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since #34 the activation of a GraphqlClientImpl throws an exception when configured endpoint url is invalid. This prevents the component to be fully registered as service. However it does not work to a full extend as expected:

a) when the configuration of a service is updated, the service is activated and registered but not re-bound to for example the `GraphqlClientAdapterFactory`
b) it causes a lot of noice in the logs

With this change the activation does not fail anymore. Instead the service registration is done manually instead of by the SCR. 

## Related Issue

CIF-2785, CIF-2710

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
