### PR TITLE
CIF-2840: add service ranking to graphql client

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
@@ -120,4 +120,10 @@ public @interface GraphqlClientConfiguration {
             + "TIMEOUT (Integer) : the timeout for each cache entry, in seconds.",
         type = AttributeType.STRING)
     String[] cacheConfigurations();
+
+    @AttributeDefinition(
+        name = "Ranking",
+        description = "Integer value defining the ranking of this queue configuration. If more than one GraphQL Client use the same "
+            + "identifier the one with the higher ranking will be used. Defaults to 0")
+    int service_ranking() default 0;
 }

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactory.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactory.java
@@ -14,10 +14,10 @@
 
 package com.adobe.cq.commerce.graphql.client.impl;
 
-import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.adapter.AdapterFactory;
@@ -54,7 +54,7 @@ public class GraphqlClientAdapterFactory implements AdapterFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphqlClientAdapterFactory.class);
 
-    protected List<Holder> clients = new CopyOnWriteArrayList<>();
+    protected NavigableSet<Holder> clients = new ConcurrentSkipListSet<>();
     protected Map<String, GraphqlClient> clientsByIdentifier = new ConcurrentHashMap<>();
     protected BundleContext bundleContext;
 
@@ -68,7 +68,6 @@ public class GraphqlClientAdapterFactory implements AdapterFactory {
         String identifier = graphqlClient.getIdentifier();
         LOGGER.info("Registering GraphqlClient '{}'", identifier);
         clients.add(new Holder(graphqlClient, properties));
-        clients.sort(null);
         clientsByIdentifier.remove(identifier);
     }
 

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfigurationImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfigurationImpl.java
@@ -36,6 +36,8 @@ class GraphqlClientConfigurationImpl implements Annotation, GraphqlClientConfigu
     private String[] cacheConfigurations = new String[0];
     private int connectionKeepAlive = GraphqlClientConfiguration.DEFAULT_CONNECTION_KEEP_ALIVE;
 
+    private int serviceRanking = 0;
+
     GraphqlClientConfigurationImpl(String url) {
         this.url = url;
     }
@@ -53,6 +55,7 @@ class GraphqlClientConfigurationImpl implements Annotation, GraphqlClientConfigu
         httpHeaders = configuration.httpHeaders() != null ? configuration.httpHeaders() : this.httpHeaders;
         cacheConfigurations = configuration.cacheConfigurations() != null ? configuration.cacheConfigurations() : this.cacheConfigurations;
         connectionKeepAlive = configuration.connectionKeepAlive();
+        serviceRanking = configuration.service_ranking();
     }
 
     @Override
@@ -166,5 +169,14 @@ class GraphqlClientConfigurationImpl implements Annotation, GraphqlClientConfigu
 
     public void setConnectionKeepAlive(int connectionKeepAlive) {
         this.connectionKeepAlive = connectionKeepAlive;
+    }
+
+    @Override
+    public int service_ranking() {
+        return serviceRanking;
+    }
+
+    public void setServiceRanking(int serviceRanking) {
+        this.serviceRanking = serviceRanking;
     }
 }

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -63,6 +63,7 @@ import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
 import org.apache.http.util.VersionInfo;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -94,6 +95,7 @@ public class GraphqlClientImpl implements GraphqlClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphqlClientImpl.class);
     private static final String USER_AGENT_NAME = "Adobe-CifGraphqlClient";
+    static final String PROP_IDENTIFIER = "identifier";
 
     protected HttpClient client;
 
@@ -188,7 +190,8 @@ public class GraphqlClientImpl implements GraphqlClient {
         client = configureHttpClientBuilder().build();
 
         Hashtable<String, Object> serviceProps = new Hashtable<>();
-        serviceProps.put("identifier", configuration.identifier());
+        serviceProps.put(PROP_IDENTIFIER, configuration.identifier());
+        serviceProps.put(Constants.SERVICE_RANKING, configuration.service_ranking());
         registration = bundleContext.registerService(GraphqlClient.class, this, serviceProps);
     }
 
@@ -296,7 +299,7 @@ public class GraphqlClientImpl implements GraphqlClient {
     }
 
     private <T, U> GraphqlResponse<T, U> executeImpl(GraphqlRequest request, Type typeOfT, Type typeofU, RequestOptions options) {
-        LOGGER.debug("Executing GraphQL query: " + request.getQuery());
+        LOGGER.debug("Executing GraphQL query on endpoint '{}': {}", configuration.url(), request.getQuery());
         Runnable stopTimer = metrics.startRequestDurationTimer();
         HttpResponse httpResponse;
         try {

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
@@ -12,5 +12,5 @@
  *
  ******************************************************************************/
 
-@org.osgi.annotation.versioning.Version("1.8.0")
+@org.osgi.annotation.versioning.Version("1.9.0")
 package com.adobe.cq.commerce.graphql.client;

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlAemContext.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlAemContext.java
@@ -70,7 +70,7 @@ public final class GraphqlAemContext {
             }).build();
         GraphqlClient mockClient = mock(GraphqlClient.class);
         when(mockClient.getIdentifier()).thenReturn(CATALOG_IDENTIFIER);
-        ctx.registerService(GraphqlClient.class, mockClient);
+        ctx.registerService(GraphqlClient.class, mockClient, GraphqlClientImpl.PROP_IDENTIFIER, CATALOG_IDENTIFIER);
 
         // Add AdapterFactory
         ctx.registerInjectActivateService(GraphqlAemContext.adapterFactory);

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
@@ -14,13 +14,14 @@
 
 package com.adobe.cq.commerce.graphql.client.impl;
 
+import java.util.Collections;
+
 import org.apache.sling.api.resource.Resource;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
-import org.osgi.framework.ServiceReference;
 
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
 import com.google.common.collect.ImmutableMap;
@@ -30,7 +31,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class GraphqlClientAdapterFactoryTest {
@@ -74,15 +74,15 @@ public class GraphqlClientAdapterFactoryTest {
     @Test
     public void testReturnNullForNotExistingResolver() {
         // Remove mockClient from resolver
-        ServiceReference<GraphqlClient> ref = context.bundleContext().getServiceReference(GraphqlClient.class);
-        GraphqlAemContext.adapterFactory.unbindGraphqlClient(ref);
+        GraphqlClient client = context.getService(GraphqlClient.class);
+        GraphqlAemContext.adapterFactory.unbindGraphqlClient(client);
         Assert.assertEquals(0, GraphqlAemContext.adapterFactory.clients.size());
 
         // Get page which has the catalog identifier in its jcr:content node
         Resource res = context.resourceResolver().getResource("/content/pageA");
 
         // Adapt page to client, verify that no client can be returned
-        GraphqlClient client = res.adaptTo(GraphqlClient.class);
+        client = res.adaptTo(GraphqlClient.class);
         Assert.assertNull(client);
     }
 
@@ -109,36 +109,12 @@ public class GraphqlClientAdapterFactoryTest {
     }
 
     @Test
-    public void testServiceUnregistered() {
-        // default service ref in use
-        GraphqlClient client = context.resourceResolver().getResource("/content/pageA").adaptTo(GraphqlClient.class);
-        assertNotNull(client);
-
-        // inject a mock bundleContext to verify the ungetService() call
-        BundleContext bundleContext = mock(BundleContext.class);
-        GraphqlAemContext.adapterFactory.activate(bundleContext);
-
-        // unregister
-        ServiceReference<GraphqlClient> ref = context.bundleContext().getServiceReference(GraphqlClient.class);
-        GraphqlAemContext.adapterFactory.unbindGraphqlClient(ref);
-
-        verify(bundleContext).ungetService(ref);
-    }
-
-    @Test
     public void testErrorCases() throws Exception {
         GraphqlClientImpl graphqlClient = new GraphqlClientImpl();
         graphqlClient.activate(new MockGraphqlClientConfiguration(), mock(BundleContext.class));
 
-        BundleContext bundleContext = mock(BundleContext.class);
-        ServiceReference<GraphqlClient> ref = mock(ServiceReference.class);
-        when(bundleContext.getService(ref)).thenReturn(graphqlClient);
-        when(ref.getProperty(GraphqlClientImpl.PROP_IDENTIFIER)).thenReturn("default");
-
         GraphqlClientAdapterFactory factory = new GraphqlClientAdapterFactory();
-        factory.activate(bundleContext);
-
-        factory.bindGraphqlClient(ref);
+        factory.bindGraphqlClient(graphqlClient, Collections.emptyMap());
 
         // Ensure that adapter returns null if not adapted from a resource
         Object target = factory.getAdapter(factory, Object.class);

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientAdapterFactoryTest.java
@@ -19,12 +19,18 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
 
 import com.adobe.cq.commerce.graphql.client.GraphqlClient;
 import com.google.common.collect.ImmutableMap;
 import io.wcm.testing.mock.aem.junit.AemContext;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class GraphqlClientAdapterFactoryTest {
@@ -68,9 +74,8 @@ public class GraphqlClientAdapterFactoryTest {
     @Test
     public void testReturnNullForNotExistingResolver() {
         // Remove mockClient from resolver
-        GraphqlClient mockClient = mock(GraphqlClient.class);
-        when(mockClient.getIdentifier()).thenReturn(GraphqlAemContext.CATALOG_IDENTIFIER);
-        GraphqlAemContext.adapterFactory.unbindGraphqlClient(mockClient, null);
+        ServiceReference<GraphqlClient> ref = context.bundleContext().getServiceReference(GraphqlClient.class);
+        GraphqlAemContext.adapterFactory.unbindGraphqlClient(ref);
         Assert.assertEquals(0, GraphqlAemContext.adapterFactory.clients.size());
 
         // Get page which has the catalog identifier in its jcr:content node
@@ -82,12 +87,58 @@ public class GraphqlClientAdapterFactoryTest {
     }
 
     @Test
+    public void testMultipleClientsWithServiceRanking() {
+        GraphqlClient additionalClient = mock(GraphqlClient.class);
+        when(additionalClient.getIdentifier()).thenReturn(GraphqlAemContext.CATALOG_IDENTIFIER);
+
+        context.registerService(GraphqlClient.class, additionalClient,
+            Constants.SERVICE_RANKING, -10,
+            GraphqlClientImpl.PROP_IDENTIFIER, GraphqlAemContext.CATALOG_IDENTIFIER);
+
+        // should get the default gql client (service ranking = 0)
+        GraphqlClient client = context.resourceResolver().getResource("/content/pageA").adaptTo(GraphqlClient.class);
+        assertNotEquals(additionalClient, client);
+
+        context.registerService(GraphqlClient.class, additionalClient,
+            Constants.SERVICE_RANKING, 10,
+            GraphqlClientImpl.PROP_IDENTIFIER, GraphqlAemContext.CATALOG_IDENTIFIER);
+
+        // should get the additional gql client (service ranking = 10)
+        client = context.resourceResolver().getResource("/content/pageA").adaptTo(GraphqlClient.class);
+        assertEquals(additionalClient, client);
+    }
+
+    @Test
+    public void testServiceUnregistered() {
+        // default service ref in use
+        GraphqlClient client = context.resourceResolver().getResource("/content/pageA").adaptTo(GraphqlClient.class);
+        assertNotNull(client);
+
+        // inject a mock bundleContext to verify the ungetService() call
+        BundleContext bundleContext = mock(BundleContext.class);
+        GraphqlAemContext.adapterFactory.activate(bundleContext);
+
+        // unregister
+        ServiceReference<GraphqlClient> ref = context.bundleContext().getServiceReference(GraphqlClient.class);
+        GraphqlAemContext.adapterFactory.unbindGraphqlClient(ref);
+
+        verify(bundleContext).ungetService(ref);
+    }
+
+    @Test
     public void testErrorCases() throws Exception {
         GraphqlClientImpl graphqlClient = new GraphqlClientImpl();
         graphqlClient.activate(new MockGraphqlClientConfiguration(), mock(BundleContext.class));
 
+        BundleContext bundleContext = mock(BundleContext.class);
+        ServiceReference<GraphqlClient> ref = mock(ServiceReference.class);
+        when(bundleContext.getService(ref)).thenReturn(graphqlClient);
+        when(ref.getProperty(GraphqlClientImpl.PROP_IDENTIFIER)).thenReturn("default");
+
         GraphqlClientAdapterFactory factory = new GraphqlClientAdapterFactory();
-        factory.bindGraphqlClient(graphqlClient, null);
+        factory.activate(bundleContext);
+
+        factory.bindGraphqlClient(ref);
 
         // Ensure that adapter returns null if not adapted from a resource
         Object target = factory.getAdapter(factory, Object.class);

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Dictionary;
 import java.util.List;
 
 import org.apache.http.Header;
@@ -35,8 +36,10 @@ import org.apache.http.protocol.HTTP;
 import org.hamcrest.CustomMatcher;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceRegistration;
 import org.slf4j.LoggerFactory;
 
@@ -111,16 +114,20 @@ public class GraphqlClientImplTest {
 
     @Test
     public void testRegistersAsGraphqlClientService() throws Exception {
+        ArgumentCaptor<Dictionary> serviceProps = ArgumentCaptor.forClass(Dictionary.class);
         // given
         BundleContext bundleContext = mock(BundleContext.class);
         ServiceRegistration registration = mock(ServiceRegistration.class);
-        when(bundleContext.registerService(eq(GraphqlClient.class), eq(graphqlClient), any())).thenReturn(registration);
+        when(bundleContext.registerService(eq(GraphqlClient.class), eq(graphqlClient), serviceProps.capture())).thenReturn(registration);
+        mockConfig.setServiceRanking(200);
 
         // when
         graphqlClient.activate(mockConfig, bundleContext);
 
         // then
         verify(bundleContext).registerService(eq(GraphqlClient.class), eq(graphqlClient), any());
+        assertEquals(200, serviceProps.getValue().get(Constants.SERVICE_RANKING));
+        assertEquals("mockIdentifier", serviceProps.getValue().get("identifier"));
 
         // and when
         graphqlClient.deactivate();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In order to allow configurations to overwrite each other we now support passing down the service ranking of a GraphqlClient to the registered service. This allows consumers to select one of many GraphqlClients by identifier respecting the defined order by ranking.

## Related Issue

CIF-2840

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

unit tests, locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
