### PR TITLE
CIF-2950 - Add request duration to debug logs

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import javax.net.ssl.SSLContext;
 
@@ -300,7 +301,7 @@ public class GraphqlClientImpl implements GraphqlClient {
 
     private <T, U> GraphqlResponse<T, U> executeImpl(GraphqlRequest request, Type typeOfT, Type typeofU, RequestOptions options) {
         LOGGER.debug("Executing GraphQL query on endpoint '{}': {}", configuration.url(), request.getQuery());
-        Runnable stopTimer = metrics.startRequestDurationTimer();
+        Supplier<Long> stopTimer = metrics.startRequestDurationTimer();
         HttpResponse httpResponse;
         try {
             httpResponse = client.execute(buildRequest(request, options));
@@ -315,7 +316,10 @@ public class GraphqlClientImpl implements GraphqlClient {
             String json;
             try {
                 json = EntityUtils.toString(entity, StandardCharsets.UTF_8);
-                stopTimer.run();
+                Long executionTime = stopTimer.get();
+                if (executionTime != null) {
+                    LOGGER.debug("Executed in {}ms", Math.floor(executionTime / 1e6));
+                }
             } catch (Exception e) {
                 metrics.incrementRequestErrors();
                 throw new RuntimeException("Failed to read HTTP response content", e);

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetrics.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetrics.java
@@ -43,10 +43,8 @@ interface GraphqlClientMetrics {
             // do nothing
         }
 
-        @Override public Runnable startRequestDurationTimer() {
-            return () -> {
-                // do nothing
-            };
+        @Override public Supplier<Long> startRequestDurationTimer() {
+            return () -> null;
         }
 
         @Override public void incrementRequestErrors() {
@@ -74,7 +72,7 @@ interface GraphqlClientMetrics {
      *
      * @return
      */
-    Runnable startRequestDurationTimer();
+    Supplier<Long> startRequestDurationTimer();
 
     /**
      * Increments the generic request error count.

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetricsImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetricsImpl.java
@@ -70,8 +70,8 @@ class GraphqlClientMetricsImpl implements GraphqlClientMetrics, Closeable {
     }
 
     @Override
-    public Runnable startRequestDurationTimer() {
-        return requestDurationTimer.time()::close;
+    public Supplier<Long> startRequestDurationTimer() {
+        return requestDurationTimer.time()::stop;
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Changed `startRequestDurationTimer` to return the request duration via `Supplier<Long>`.
* Added debug log message with duration for all successful GraphQL requests where metrics are available.

## How Has This Been Tested?

* Manually with debug logging enabled

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
