### PR TITLE
CIF-2976: support disabling connection reuse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.9.0</version>
+                <version>2.16.0</version>
                 <executions>
                     <execution>
                         <id>verify-code-formatting</id>
@@ -490,7 +490,6 @@
                     <plugin>
                         <groupId>net.revelc.code.formatter</groupId>
                         <artifactId>formatter-maven-plugin</artifactId>
-                        <version>2.9.0</version>
                         <executions>
                             <execution>
                                 <id>format-code</id>

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
@@ -108,8 +108,9 @@ public @interface GraphqlClientConfiguration {
 
     @AttributeDefinition(
         name = "Connection time to live",
-        description = "The maximum number of seconds a connections is reused for. If the value is <= 0 the connection may be reused "
-            + "indefinitely, depending on the configured connection keep alive timeout. Defaults to " + DEFAULT_CONNECTION_TTL,
+        description = "The maximum number of seconds a connections is reused for. If the value is < 0, the connection may be reused "
+            + "indefinitely, depending on the configured connection keep alive timeout. If the value is 0, connections will never be "
+            + "reused. Defaults to " + DEFAULT_CONNECTION_TTL,
         type = AttributeType.INTEGER)
     int connectionTtl() default DEFAULT_CONNECTION_TTL;
 

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
@@ -101,15 +101,15 @@ public @interface GraphqlClientConfiguration {
     @AttributeDefinition(
         name = "Connection keep alive timeout",
         description = "The maximum number of seconds an unused connections is kept alive in the connection pool after the last response. "
-            + "If the value is < 0 than connections are kept alive indefinitely. If the value is 0 than connection reuse is disabled. "
+            + "If the value is < 0 then connections are kept alive indefinitely. If the value is 0 then connections will never be reused. "
             + "Defaults to " + DEFAULT_CONNECTION_KEEP_ALIVE,
         type = AttributeType.INTEGER)
     int connectionKeepAlive() default DEFAULT_CONNECTION_KEEP_ALIVE;
 
     @AttributeDefinition(
         name = "Connection time to live",
-        description = "The maximum number of seconds a connections is reused for. If the value is < 0, the connection may be reused "
-            + "indefinitely, depending on the configured connection keep alive timeout. If the value is 0, connections will never be "
+        description = "The maximum number of seconds a connections is reused for. If the value is < 0 then the connection may be reused "
+            + "indefinitely, depending on the configured connection keep alive timeout. If the value is 0 then connections will never be "
             + "reused. Defaults to " + DEFAULT_CONNECTION_TTL,
         type = AttributeType.INTEGER)
     int connectionTtl() default DEFAULT_CONNECTION_TTL;

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClientConfiguration.java
@@ -32,6 +32,7 @@ public @interface GraphqlClientConfiguration {
     int DEFAULT_SOCKET_TIMEOUT = 5000;
     int DEFAULT_REQUESTPOOL_TIMEOUT = 2000;
     int DEFAULT_CONNECTION_KEEP_ALIVE = -1;
+    int DEFAULT_CONNECTION_TTL = -1;
 
     @AttributeDefinition(
         name = "GraphQL Service Identifier",
@@ -99,10 +100,18 @@ public @interface GraphqlClientConfiguration {
 
     @AttributeDefinition(
         name = "Connection keep alive timeout",
-        description = "The maximum number of seconds an unused connections is kept in the connection pool. If the value is < 0 than "
-            + "connections are kept alive indefinitely. Defaults to " + DEFAULT_CONNECTION_KEEP_ALIVE,
+        description = "The maximum number of seconds an unused connections is kept alive in the connection pool after the last response. "
+            + "If the value is < 0 than connections are kept alive indefinitely. If the value is 0 than connection reuse is disabled. "
+            + "Defaults to " + DEFAULT_CONNECTION_KEEP_ALIVE,
         type = AttributeType.INTEGER)
     int connectionKeepAlive() default DEFAULT_CONNECTION_KEEP_ALIVE;
+
+    @AttributeDefinition(
+        name = "Connection time to live",
+        description = "The maximum number of seconds a connections is reused for. If the value is <= 0 the connection may be reused "
+            + "indefinitely, depending on the configured connection keep alive timeout. Defaults to " + DEFAULT_CONNECTION_TTL,
+        type = AttributeType.INTEGER)
+    int connectionTtl() default DEFAULT_CONNECTION_TTL;
 
     @AttributeDefinition(
         name = "Default HTTP Headers",

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfigurationImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientConfigurationImpl.java
@@ -35,7 +35,7 @@ class GraphqlClientConfigurationImpl implements Annotation, GraphqlClientConfigu
     private String[] httpHeaders = new String[0];
     private String[] cacheConfigurations = new String[0];
     private int connectionKeepAlive = GraphqlClientConfiguration.DEFAULT_CONNECTION_KEEP_ALIVE;
-
+    private int connectionTtl = GraphqlClientConfiguration.DEFAULT_CONNECTION_TTL;
     private int serviceRanking = 0;
 
     GraphqlClientConfigurationImpl(String url) {
@@ -55,6 +55,7 @@ class GraphqlClientConfigurationImpl implements Annotation, GraphqlClientConfigu
         httpHeaders = configuration.httpHeaders() != null ? configuration.httpHeaders() : this.httpHeaders;
         cacheConfigurations = configuration.cacheConfigurations() != null ? configuration.cacheConfigurations() : this.cacheConfigurations;
         connectionKeepAlive = configuration.connectionKeepAlive();
+        connectionTtl = configuration.connectionTtl();
         serviceRanking = configuration.service_ranking();
     }
 
@@ -169,6 +170,15 @@ class GraphqlClientConfigurationImpl implements Annotation, GraphqlClientConfigu
 
     public void setConnectionKeepAlive(int connectionKeepAlive) {
         this.connectionKeepAlive = connectionKeepAlive;
+    }
+
+    @Override
+    public int connectionTtl() {
+        return connectionTtl;
+    }
+
+    public void setConnectionTtl(int connectionTtl) {
+        this.connectionTtl = connectionTtl;
     }
 
     @Override

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -13,6 +13,7 @@
  ******************************************************************************/
 package com.adobe.cq.commerce.graphql.client.impl;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.MalformedURLException;
@@ -51,6 +52,7 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicHeaderElementIterator;
@@ -202,6 +204,13 @@ public class GraphqlClientImpl implements GraphqlClient {
         }
         if (registration != null) {
             registration.unregister();
+        }
+        if (client instanceof CloseableHttpClient) {
+            try {
+                ((CloseableHttpClient) client).close();
+            } catch (IOException ex) {
+                LOGGER.warn("Failed to close http client: {}", ex.getMessage(), ex);
+            }
         }
     }
 

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetrics.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientMetrics.java
@@ -35,23 +35,28 @@ interface GraphqlClientMetrics {
 
     GraphqlClientMetrics NOOP = new GraphqlClientMetrics() {
 
-        @Override public void addConnectionPoolMetric(String metricName, Supplier<? extends Number> valueSupplier) {
-            //do nothing
-        }
-
-        @Override public void addCacheMetric(String metricName, String cacheName, Supplier<? extends Number> valueSupplier) {
+        @Override
+        public void addConnectionPoolMetric(String metricName, Supplier<? extends Number> valueSupplier) {
             // do nothing
         }
 
-        @Override public Supplier<Long> startRequestDurationTimer() {
+        @Override
+        public void addCacheMetric(String metricName, String cacheName, Supplier<? extends Number> valueSupplier) {
+            // do nothing
+        }
+
+        @Override
+        public Supplier<Long> startRequestDurationTimer() {
             return () -> null;
         }
 
-        @Override public void incrementRequestErrors() {
+        @Override
+        public void incrementRequestErrors() {
             // do nothing
         }
 
-        @Override public void incrementRequestErrors(int status) {
+        @Override
+        public void incrementRequestErrors(int status) {
             // do nothing
         }
     };

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
@@ -12,5 +12,5 @@
  *
  ******************************************************************************/
 
-@org.osgi.annotation.versioning.Version("1.9.0")
+@org.osgi.annotation.versioning.Version("1.10.0")
 package com.adobe.cq.commerce.graphql.client;

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplCachingTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplCachingTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
 import org.apache.http.message.BasicHeader;
 import org.junit.Before;
 import org.junit.Test;
@@ -102,7 +103,7 @@ public class GraphqlClientImplCachingTest {
         assertEquals(42, response2.getData().count.intValue());
 
         // HTTP client was only called once
-        Mockito.verify(graphqlClient.client).execute(Mockito.any());
+        Mockito.verify(graphqlClient.client).execute(Mockito.any(), Mockito.any(ResponseHandler.class));
     }
 
     @Test
@@ -126,7 +127,7 @@ public class GraphqlClientImplCachingTest {
         assertEquals(42, response2.getData().count.intValue());
 
         // HTTP client was called twice
-        Mockito.verify(graphqlClient.client, Mockito.times(2)).execute(Mockito.any());
+        Mockito.verify(graphqlClient.client, Mockito.times(2)).execute(Mockito.any(), Mockito.any(ResponseHandler.class));
     }
 
     @Test
@@ -155,7 +156,7 @@ public class GraphqlClientImplCachingTest {
         assertEquals(42, response2.getData().count.intValue());
 
         // HTTP client was called twice
-        Mockito.verify(graphqlClient.client, Mockito.times(2)).execute(Mockito.any());
+        Mockito.verify(graphqlClient.client, Mockito.times(2)).execute(Mockito.any(), Mockito.any(ResponseHandler.class));
     }
 
     @Test
@@ -257,6 +258,6 @@ public class GraphqlClientImplCachingTest {
         assertEquals(42, response2.getData().count.intValue());
 
         // HTTP client was called twice
-        Mockito.verify(graphqlClient.client, Mockito.times(2)).execute(Mockito.any());
+        Mockito.verify(graphqlClient.client, Mockito.times(2)).execute(Mockito.any(), Mockito.any(ResponseHandler.class));
     }
 }

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplMetricsTest.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.osgi.services.HttpClientBuilderFactory;
 import org.apache.sling.testing.mock.osgi.MockOsgi;
@@ -138,7 +139,7 @@ public class GraphqlClientImplMetricsTest {
     @Test
     public void testRequestDurationNotTrackedOnClientError() throws IOException {
         // given
-        doThrow(new IOException()).when(graphqlClient.client).execute(any());
+        doThrow(new IOException()).when(graphqlClient.client).execute(any(), any(ResponseHandler.class));
 
         // when
         try {

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImplTest.java
@@ -28,6 +28,8 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.conn.ConnectionKeepAliveStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
@@ -216,7 +218,7 @@ public class GraphqlClientImplTest {
 
         // Check that the HTTP client is sending the custom request headers and the headers set in the OSGi config
         HeadersMatcher matcher = new HeadersMatcher(expectedHeaders);
-        Mockito.verify(graphqlClient.client, Mockito.times(1)).execute(Mockito.argThat(matcher));
+        Mockito.verify(graphqlClient.client, Mockito.times(1)).execute(Mockito.argThat(matcher), Mockito.any(ResponseHandler.class));
     }
 
     @Test
@@ -230,7 +232,7 @@ public class GraphqlClientImplTest {
         // Check that the query is what we expect
         String body = TestUtils.getResource("sample-graphql-request.json");
         RequestBodyMatcher matcher = new RequestBodyMatcher(body);
-        Mockito.verify(graphqlClient.client, Mockito.times(1)).execute(Mockito.argThat(matcher));
+        Mockito.verify(graphqlClient.client, Mockito.times(1)).execute(Mockito.argThat(matcher), Mockito.any(ResponseHandler.class));
 
         // Check the response data
         assertEquals("Some text", response.getData().text);
@@ -257,7 +259,7 @@ public class GraphqlClientImplTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testHttpClientException() throws Exception {
-        Mockito.when(graphqlClient.client.execute(Mockito.any())).thenThrow(IOException.class);
+        when(graphqlClient.client.execute(any(HttpUriRequest.class), any(ResponseHandler.class))).thenThrow(IOException.class);
         Exception exception = null;
         try {
             graphqlClient.execute(dummy, Data.class, Error.class);
@@ -326,7 +328,7 @@ public class GraphqlClientImplTest {
 
         // Check that the HTTP client is sending the custom request headers and the headers set in the OSGi config
         HeadersMatcher matcher = new HeadersMatcher(expectedHeaders);
-        Mockito.verify(graphqlClient.client, Mockito.times(1)).execute(Mockito.argThat(matcher));
+        Mockito.verify(graphqlClient.client, Mockito.times(1)).execute(Mockito.argThat(matcher), Mockito.any(ResponseHandler.class));
     }
 
     @Test
@@ -336,7 +338,7 @@ public class GraphqlClientImplTest {
 
         // Check that the GraphQL request is properly encoded in the URL
         GetQueryMatcher matcher = new GetQueryMatcher(dummy);
-        Mockito.verify(graphqlClient.client, Mockito.times(1)).execute(Mockito.argThat(matcher));
+        Mockito.verify(graphqlClient.client, Mockito.times(1)).execute(Mockito.argThat(matcher), Mockito.any(ResponseHandler.class));
     }
 
     @Test
@@ -351,7 +353,7 @@ public class GraphqlClientImplTest {
 
         // Check that the GraphQL request is properly encoded in the URL
         GetQueryMatcher matcher = new GetQueryMatcher(request);
-        Mockito.verify(graphqlClient.client, Mockito.times(1)).execute(Mockito.argThat(matcher));
+        Mockito.verify(graphqlClient.client, Mockito.times(1)).execute(Mockito.argThat(matcher), Mockito.any(ResponseHandler.class));
     }
 
     @Test

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/TestUtils.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/TestUtils.java
@@ -30,6 +30,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -142,7 +143,6 @@ public class TestUtils {
      * @param filename The file to use for the json response.
      * @param httpClient The HTTP client for which we want to mock responses.
      * @param httpCode The http code that the mocked response will return.
-     * @param startsWith When set, the body of the GraphQL POST request must start with that String.
      * 
      * @return The JSON content of that file.
      * 
@@ -160,7 +160,10 @@ public class TestUtils {
         Mockito.when(mockedHttpEntity.getContentLength()).thenReturn(new Long(bytes.length));
 
         Mockito.when(mockedHttpResponse.getEntity()).thenReturn(mockedHttpEntity);
-        Mockito.when(httpClient.execute((HttpUriRequest) Mockito.any())).thenReturn(mockedHttpResponse);
+        Mockito.doAnswer(inv -> {
+            ResponseHandler<?> responseHandler = inv.getArgumentAt(1, ResponseHandler.class);
+            return responseHandler.handleResponse(mockedHttpResponse);
+        }).when(httpClient).execute(Mockito.any(HttpUriRequest.class), Mockito.any(ResponseHandler.class));
 
         Mockito.when(mockedStatusLine.getStatusCode()).thenReturn(httpCode);
         Mockito.when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);
@@ -176,7 +179,10 @@ public class TestUtils {
         Mockito.when(mockedHttpEntity.getContent()).thenReturn(data);
 
         Mockito.when(mockedHttpResponse.getEntity()).thenReturn(mockedHttpEntity);
-        Mockito.when(httpClient.execute((HttpUriRequest) Mockito.any())).thenReturn(mockedHttpResponse);
+        Mockito.doAnswer(inv -> {
+            ResponseHandler<?> responseHandler = inv.getArgumentAt(1, ResponseHandler.class);
+            return responseHandler.handleResponse(mockedHttpResponse);
+        }).when(httpClient).execute(Mockito.any(HttpUriRequest.class), Mockito.any(ResponseHandler.class));
 
         Mockito.when(mockedStatusLine.getStatusCode()).thenReturn(httpCode);
         Mockito.when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);
@@ -187,7 +193,10 @@ public class TestUtils {
         StatusLine mockedStatusLine = Mockito.mock(StatusLine.class);
 
         Mockito.when(mockedHttpResponse.getEntity()).thenReturn(null);
-        Mockito.when(httpClient.execute((HttpUriRequest) Mockito.any())).thenReturn(mockedHttpResponse);
+        Mockito.doAnswer(inv -> {
+            ResponseHandler<?> responseHandler = inv.getArgumentAt(1, ResponseHandler.class);
+            return responseHandler.handleResponse(mockedHttpResponse);
+        }).when(httpClient).execute(Mockito.any(HttpUriRequest.class), Mockito.any(ResponseHandler.class));
 
         Mockito.when(mockedStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
         Mockito.when(mockedHttpResponse.getStatusLine()).thenReturn(mockedStatusLine);


### PR DESCRIPTION
- add connection ttl configuration
- disable connection reuse when either ttl or keep alive are set to 0
- make use of a `ResponseHandler` to ease freeing httpclient related resources
- close httpclient on service deactivate
