### PR TITLE
SITES-11765: expose an API to invalidate graphql client cache

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClient.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/GraphqlClient.java
@@ -24,14 +24,14 @@ public interface GraphqlClient {
     /**
      * Returns the identifier of this GraphQL client and backing OSGi service.
      * This can be set on JCR resources with the <code>cq:graphqlClient</code> property.
-     * 
+     *
      * @return The identifier value of this client.
      */
     public String getIdentifier();
 
     /**
      * Returns the URL of the used GraphQL server endpoint.
-     * 
+     *
      * @return The backend GraphQL server endpoint used by this client.
      */
     public String getGraphQLEndpoint();
@@ -48,31 +48,31 @@ public interface GraphqlClient {
      * The type T is used to deserialize the 'data' object of the GraphQL response, and the type U is used
      * to deserialize the 'errors' array of the GraphQL response.
      * Each generic type can be a simple class or a generic class. To specify a simple class, just do:
-     * 
+     *
      * <pre>
      * GraphqlResponse&lt;MyData, MyError&gt; response = graphqlClient.execute(request, MyData.class, MyError.class);
      * MyData data = response.getData();
      * List&lt;MyError&gt; errors = response.getErrors();
      * </pre>
-     * 
+     *
      * To specify a generic type (usually for the type T), one can use
      * the {@link com.google.gson.reflect.TypeToken} class. For example:
-     * 
+     *
      * <pre>
      * Type typeOfT = new TypeToken&lt;List&lt;String&gt;&gt;() {}.getType();
      * GraphqlResponse&lt;List&lt;String&gt;, MyError&gt; response = graphqlClient.execute(request, typeOfT, MyError.class);
      * List&lt;String&gt; data = response.getData();
      * </pre>
-     * 
+     *
      * @param request The GraphQL request.
      * @param typeOfT The type of the expected GraphQL response 'data' field.
      * @param typeOfU The type of the elements of the expected GraphQL response 'errors' field.
-     * 
+     *
      * @param <T> The generic type of the 'data' object in the JSON GraphQL response.
      * @param <U> The generic type of the elements of the 'errors' array in the JSON GraphQL response.
-     * 
+     *
      * @return A GraphQL response.
-     * 
+     *
      * @exception RuntimeException if the GraphQL HTTP request does not return 200 or if the JSON response cannot be parsed or deserialized.
      */
     public <T, U> GraphqlResponse<T, U> execute(GraphqlRequest request, Type typeOfT, Type typeOfU);
@@ -82,34 +82,47 @@ public interface GraphqlClient {
      * The type T is used to deserialize the 'data' object of the GraphQL response, and the type U is used
      * to deserialize the 'errors' array of the GraphQL response.
      * Each generic type can be a simple class or a generic class. To specify a simple class, just do:
-     * 
+     *
      * <pre>
      * GraphqlResponse&lt;MyData, MyError&gt; response = graphqlClient.execute(request, MyData.class, MyError.class);
      * MyData data = response.getData();
      * List&lt;MyError&gt; errors = response.getErrors();
      * </pre>
-     * 
+     *
      * To specify a generic type (usually for the type T), one can use
      * the {@link com.google.gson.reflect.TypeToken} class. For example:
-     * 
+     *
      * <pre>
      * Type typeOfT = new TypeToken&lt;List&lt;String&gt;&gt;() {}.getType();
      * GraphqlResponse&lt;List&lt;String&gt;, MyError&gt; response = graphqlClient.execute(request, typeOfT, MyError.class);
      * List&lt;String&gt; data = response.getData();
      * </pre>
-     * 
+     *
      * @param request The GraphQL request.
      * @param typeOfT The type of the expected GraphQL response 'data' field.
      * @param typeOfU The type of the elements of the expected GraphQL response 'errors' field.
      * @param options An object holding options that can be set when executing the request.
-     * 
+     *
      * @param <T> The generic type of the 'data' object in the JSON GraphQL response.
      * @param <U> The generic type of the elements of the 'errors' array in the JSON GraphQL response.
-     * 
+     *
      * @return A GraphQL response.
-     * 
+     *
      * @exception RuntimeException if the GraphQL HTTP request does not return 200 or if the JSON response cannot be parsed or deserialized.
      */
     public <T, U> GraphqlResponse<T, U> execute(GraphqlRequest request, Type typeOfT, Type typeOfU, RequestOptions options);
+
+    /**
+     * Invalidates all caches of the GraphqlClient.
+     */
+    void invalidateCaches();
+
+    /**
+     * Invalidates the cache given by name. A list of all caches configured for this {@link GraphqlClient} can be obtained from the
+     * {@link GraphqlClientConfiguration} returned by {@link GraphqlClient#getConfiguration()}.
+     *
+     * @param name the cache name
+     */
+    void invalidateCache(String name);
 
 }

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/impl/GraphqlClientImpl.java
@@ -438,6 +438,21 @@ public class GraphqlClientImpl implements GraphqlClient {
         return rb.build();
     }
 
+    @Override
+    public void invalidateCaches() {
+        for (Cache<?, ?> cache : caches.values()) {
+            cache.invalidateAll();
+        }
+    }
+
+    @Override
+    public void invalidateCache(String name) {
+        Cache<?, ?> cache = caches.get(name);
+        if (cache != null) {
+            cache.invalidateAll();
+        }
+    }
+
     static class ConfigurableConnectionKeepAliveStrategy implements ConnectionKeepAliveStrategy {
         private int defaultConnectionKeepAlive;
 

--- a/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
+++ b/src/main/java/com/adobe/cq/commerce/graphql/client/package-info.java
@@ -12,5 +12,5 @@
  *
  ******************************************************************************/
 
-@org.osgi.annotation.versioning.Version("1.10.0")
+@org.osgi.annotation.versioning.Version("1.11.0")
 package com.adobe.cq.commerce.graphql.client;

--- a/src/test/java/com/adobe/cq/commerce/graphql/client/impl/TestUtils.java
+++ b/src/test/java/com/adobe/cq/commerce/graphql/client/impl/TestUtils.java
@@ -156,7 +156,7 @@ public class TestUtils {
         StatusLine mockedStatusLine = Mockito.mock(StatusLine.class);
 
         byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
-        Mockito.when(mockedHttpEntity.getContent()).thenReturn(new ByteArrayInputStream(bytes));
+        Mockito.when(mockedHttpEntity.getContent()).then(inv -> new ByteArrayInputStream(bytes));
         Mockito.when(mockedHttpEntity.getContentLength()).thenReturn(new Long(bytes.length));
 
         Mockito.when(mockedHttpResponse.getEntity()).thenReturn(mockedHttpEntity);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows applications to invalidate the graphql client cache. 

## Related Issue

SITES-11765
https://github.com/adobe/commerce-cif-graphql-client/pull/35

## Motivation and Context

It is in general quite complex to decide when to flush the graphql client cache(s). The cache does not know about the actual entities but only the queries, neither is there yet a mechanism to get notified when the cache needs to be flushed from the 3rd party commerce system.

Projects may however be able to implement a specific handler and so actively flush the cache when needed. (e.g. based on events or an HTTP API).

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
